### PR TITLE
Move evaluation and custom function logic to new `Environment` struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,17 @@ Implementation of [expr](https://expr-lang.org/) in rust.
 ## Usage
 
 ```rust
-use expr::{Context, Parser};
+use expr::{Context, Environment, self};
 
 fn main() {
-    let mut p = Parser::new();
-
     let mut ctx = Context::default();
     ctx.insert("two".to_string(), 2);
 
-    let three: i64 = p.eval("1 + two", &ctx).unwrap().as_number().unwrap();
+    let three: i64 = expr::eval("1 + two", &ctx).unwrap().as_number().unwrap();
     assert_eq!(three, 3);
 
-    p.add_function("add", |c| {
+    let mut env = Environment::new();
+    env.add_function("add", |c| {
         let mut sum = 0;
         for arg in c.args {
             sum += arg.as_number().unwrap();
@@ -24,7 +23,7 @@ fn main() {
         Ok(sum.into())
     });
 
-    let six: i64 = p.eval("add(1, two, 3)", &ctx).unwrap().as_number().unwrap();
+    let six: i64 = env.eval("add(1, two, 3)", &ctx).unwrap().as_number().unwrap();
     assert_eq!(six, 6);
 }
 ```

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,7 +1,7 @@
 use crate::ast::node::Node;
 use crate::Value::{Array, Bool, Float, Map, Number, String};
 use crate::{bail, Result, Rule};
-use crate::{Context, Parser, Value};
+use crate::{Context, Environment, Value};
 use pest::iterators::{Pair};
 use std::str::FromStr;
 use log::trace;
@@ -58,7 +58,7 @@ impl From<Pair<'_, Rule>> for Operator {
     }
 }
 
-impl Parser<'_> {
+impl Environment<'_> {
     pub fn eval_operator(
         &self,
         ctx: &Context,

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 use crate::ast::node::Node;
 use crate::Rule;
 use crate::{bail, Result};
-use crate::{Context, Parser, Value};
+use crate::{Context, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
 
@@ -51,7 +51,7 @@ impl From<Pair<'_, Rule>> for PostfixOperator {
     }
 }
 
-impl Parser<'_> {
+impl Environment<'_> {
     pub fn eval_postfix_operator(
         &self,
         ctx: &Context,
@@ -105,7 +105,7 @@ impl Parser<'_> {
                         .map(|arg| self.eval_expr(ctx, arg))
                         .chain(once(Ok(value)))
                         .collect::<Result<Vec<Value>>>()?;
-                    self.exec_func(ctx, ident, args, predicate.map(|p| *p))?
+                    self.eval_func(ctx, ident, args, predicate.map(|p| *p))?
                 } else {
                     bail!("Invalid operand for operator |");
                 }

--- a/src/ast/unary_operator.rs
+++ b/src/ast/unary_operator.rs
@@ -3,7 +3,7 @@ use crate::ast::unary_operator::UnaryOperator::Not;
 use crate::Rule;
 use crate::Value::Bool;
 use crate::{bail, Result};
-use crate::{Context, Parser, Value};
+use crate::{Context, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
 use std::str::FromStr;
@@ -25,7 +25,7 @@ impl From<Pair<'_, Rule>> for UnaryOperator {
     }
 }
 
-impl Parser<'_> {
+impl Environment<'_> {
     pub fn eval_unary_operator(
         &self,
         ctx: &Context,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,176 @@
+use crate::ast::node::Node;
+use crate::ast::program::Program;
+use crate::functions::{array, string, ExprCall, Function};
+use crate::{bail, Context, Result, Value};
+use crate::parser::compile;
+use indexmap::IndexMap;
+use once_cell::sync::Lazy;
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+/// Run a compiled expr program, using the default environment
+pub fn run(program: Program, ctx: &Context) -> Result<Value> {
+    DEFAULT_ENVIRONMENT.run(program, ctx)
+}
+
+/// Compile and run an expr program in one step, using the default environment.
+///
+/// Example:
+/// ```
+/// use expr::{Context, eval};
+/// let ctx = Context::default();
+/// assert_eq!(eval("1 + 2", &ctx).unwrap().to_string(), "3");
+/// ```
+pub fn eval(code: &str, ctx: &Context) -> Result<Value> {
+    DEFAULT_ENVIRONMENT.eval(code, ctx)
+}
+
+/// Struct containing custom environment setup for expr evaluation (e.g. custom
+/// function definitions)
+///
+/// Example:
+///
+/// ```
+/// use expr::{Context, Environment, Value};
+/// let mut env = Environment::new();
+/// let ctx = Context::default();
+/// env.add_function("add", |c| {
+///   let mut sum = 0;
+///     for arg in c.args {
+///       if let Value::Number(n) = arg {
+///         sum += n;
+///        } else {
+///          panic!("Invalid argument: {arg:?}");
+///        }
+///     }
+///   Ok(sum.into())
+/// });
+/// assert_eq!(env.eval("add(1, 2, 3)", &ctx).unwrap().to_string(), "6");
+/// ```
+#[derive(Default)]
+pub struct Environment<'a> {
+    pub(crate) functions: IndexMap<String, Function<'a>>,
+}
+
+impl Debug for Environment<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("ExprEnvironment").finish()
+    }
+}
+
+impl<'a> Environment<'a> {
+    /// Create a new environment with default set of functions
+    pub fn new() -> Self {
+        let mut p = Self {
+            functions: IndexMap::new(),
+        };
+        string::add_string_functions(&mut p);
+        array::add_array_functions(&mut p);
+        p
+    }
+
+    /// Add a function for expr programs to call
+    ///
+    /// Example:
+    /// ```
+    /// use expr::{Context, Environment, Value};
+    /// let mut env = Environment::new();
+    /// let ctx = Context::default();
+    /// env.add_function("add", |c| {
+    ///   let mut sum = 0;
+    ///     for arg in c.args {
+    ///       if let Value::Number(n) = arg {
+    ///         sum += n;
+    ///        } else {
+    ///          panic!("Invalid argument: {arg:?}");
+    ///        }
+    ///     }
+    ///   Ok(sum.into())
+    /// });
+    /// assert_eq!(env.eval("add(1, 2, 3)", &ctx).unwrap().to_string(), "6");
+    /// ```
+    pub fn add_function<F>(&mut self, name: &str, f: F)
+    where
+        F: Fn(ExprCall) -> Result<Value> + 'a + Sync + Send,
+    {
+        self.functions.insert(name.to_string(), Box::new(f));
+    }
+
+    /// Run a compiled expr program
+    pub fn run(&self, program: Program, ctx: &Context) -> Result<Value> {
+        let mut ctx = ctx.clone();
+        ctx.insert("$env".to_string(), Value::Map(ctx.0.clone()));
+        for (id, expr) in program.lines {
+            ctx.insert(id, self.eval_expr(&ctx, expr)?);
+        }
+        self.eval_expr(&ctx, program.expr)
+    }
+
+    /// Compile and run an expr program in one step
+    ///
+    /// Example:
+    /// ```
+    /// use std::collections::HashMap;
+    /// use expr::{Context, Environment};
+    /// let env = Environment::new();
+    /// let ctx = Context::default();
+    /// assert_eq!(env.eval("1 + 2", &ctx).unwrap().to_string(), "3");
+    /// ```
+    pub fn eval(&self, code: &str, ctx: &Context) -> Result<Value> {
+        let program = compile(code)?;
+        self.run(program, ctx)
+    }
+
+    pub fn eval_expr(&self, ctx: &Context, node: Node) -> Result<Value> {
+        let value = match node {
+            Node::Value(value) => value,
+            Node::Ident(id) => {
+                if let Some(value) = ctx.get(&id) {
+                    value.clone()
+                } else if let Some(item) = ctx
+                    .get("#")
+                    .and_then(|o| o.as_map())
+                    .and_then(|m| m.get(&id))
+                {
+                    item.clone()
+                } else {
+                    bail!("unknown variable: {id}")
+                }
+            }
+            Node::Func {
+                ident,
+                args,
+                predicate,
+            } => {
+                let args = args
+                    .into_iter()
+                    .map(|e| self.eval_expr(ctx, e))
+                    .collect::<Result<_>>()?;
+                self.eval_func(ctx, ident, args, predicate.map(|l| *l))?
+            },
+            Node::Operation {
+                left,
+                operator,
+                right,
+            } => self.eval_operator(ctx, operator, *left, *right)?,
+            Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, *node)?,
+            Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, *node)?,
+            Node::Array(a) => Value::Array(
+                a.into_iter()
+                    .map(|e| self.eval_expr(ctx, e))
+                    .collect::<Result<_>>()?,
+            ), // node => bail!("unexpected node: {node:?}"),
+            Node::Range(start, end) => match (self.eval_expr(ctx, *start)?, self.eval_expr(ctx, *end)?) {
+                (Value::Number(start), Value::Number(end)) => {
+                    Value::Array((start..=end).map(Value::Number).collect())
+                }
+                (start, end) => bail!("invalid range: {start:?}..{end:?}"),
+            }
+        };
+        Ok(value)
+    }
+}
+
+pub(crate) static DEFAULT_ENVIRONMENT: Lazy<Environment> = Lazy::new(|| {
+    Environment::new()
+});

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -1,8 +1,8 @@
 use indexmap::IndexMap;
-use crate::{bail, Parser, Value};
+use crate::{bail, Environment, Value};
 
-pub fn add_array_functions(p: &mut Parser) {
-    p.add_function("all", |c| {
+pub fn add_array_functions(env: &mut Environment) {
+    env.add_function("all", |c| {
         if c.args.len() != 1 {
             bail!("all() takes exactly one argument and a predicate");
         }
@@ -10,7 +10,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(false) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(false) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(false.into());
                 }
             }
@@ -20,7 +20,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("any", |c| {
+    env.add_function("any", |c| {
         if c.args.len() != 1 {
             bail!("any() takes exactly one argument and a predicate");
         }
@@ -28,7 +28,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(true.into());
                 }
             }
@@ -38,7 +38,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("one", |c| {
+    env.add_function("one", |c| {
         if c.args.len() != 1 {
             bail!("one() takes exactly one argument and a predicate");
         }
@@ -47,7 +47,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     if found {
                         return Ok(false.into());
                     }
@@ -60,7 +60,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("none", |c| {
+    env.add_function("none", |c| {
         if c.args.len() != 1 {
             bail!("none() takes exactly one argument and a predicate");
         }
@@ -68,7 +68,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(false.into());
                 }
             }
@@ -78,7 +78,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("map", |c| {
+    env.add_function("map", |c| {
         let mut result = Vec::new();
         if c.args.len() != 1 {
             bail!("map() takes exactly one argument and a predicate");
@@ -87,7 +87,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                result.push(c.parser.run(predicate.clone(), &ctx)?);
+                result.push(c.env.run(predicate.clone(), &ctx)?);
             }
         } else {
             bail!("map() takes an array as the first argument");
@@ -95,7 +95,7 @@ pub fn add_array_functions(p: &mut Parser) {
         Ok(result.into())
     });
 
-    p.add_function("filter", |c| {
+    env.add_function("filter", |c| {
         let mut result = Vec::new();
         if c.args.len() != 1 {
             bail!("filter() takes exactly one argument and a predicate");
@@ -104,7 +104,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     result.push(value.clone());
                 }
             }
@@ -114,7 +114,7 @@ pub fn add_array_functions(p: &mut Parser) {
         Ok(result.into())
     });
 
-    p.add_function("find", |c| {
+    env.add_function("find", |c| {
         if c.args.len() != 1 {
             bail!("find() takes exactly one argument and a predicate");
         }
@@ -122,7 +122,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(value.clone());
                 }
             }
@@ -132,7 +132,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("findIndex", |c| {
+    env.add_function("findIndex", |c| {
         if c.args.len() != 1 {
             bail!("findIndex() takes exactly one argument and a predicate");
         }
@@ -140,7 +140,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for (i, value) in a.iter().enumerate() {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(i.into());
                 }
             }
@@ -150,7 +150,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("findLast", |c| {
+    env.add_function("findLast", |c| {
         if c.args.len() != 1 {
             bail!("findLast() takes exactly one argument and a predicate");
         }
@@ -158,7 +158,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a.iter().rev() {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(value.clone());
                 }
             }
@@ -168,7 +168,7 @@ pub fn add_array_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("findLastIndex", |c| {
+    env.add_function("findLastIndex", |c| {
         if c.args.len() != 1 {
             bail!("findLastIndex() takes exactly one argument and a predicate");
         }
@@ -176,7 +176,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for (i, value) in a.iter().enumerate().rev() {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.parser.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
                     return Ok(i.into());
                 }
             }
@@ -185,7 +185,7 @@ pub fn add_array_functions(p: &mut Parser) {
             bail!("findLastIndex() takes an array as the first argument");
         }
     });
-    p.add_function("groupBy", |c| {
+    env.add_function("groupBy", |c| {
         if c.args.len() != 1 {
             bail!("groupBy() takes exactly two arguments");
         }
@@ -194,7 +194,7 @@ pub fn add_array_functions(p: &mut Parser) {
             for value in a {
                 let mut ctx = c.ctx.clone();
                 ctx.insert("#".to_string(), value.clone());
-                if let Some(key) = c.parser.run(predicate.clone(), &ctx)?.as_string() {
+                if let Some(key) = c.env.run(predicate.clone(), &ctx)?.as_string() {
                     groups.entry(key.to_string()).or_insert_with(Vec::new).push(value.clone());
                 } else {
                     bail!("groupBy() predicate must return a string");

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -4,7 +4,7 @@ pub mod array;
 use crate::Result;
 
 use crate::ast::program::Program;
-use crate::{bail, Context, Parser, Value};
+use crate::{bail, Context, Environment, Value};
 
 pub type Function<'a> = Box<dyn Fn(ExprCall) -> Result<Value> + 'a + Sync + Send>;
 
@@ -13,17 +13,17 @@ pub struct ExprCall<'a, 'b> {
     pub args: Vec<Value>,
     pub predicate: Option<Program>,
     pub ctx: &'a Context,
-    pub parser: &'a Parser<'b>,
+    pub env: &'a Environment<'b>,
 }
 
-impl Parser<'_> {
-    pub fn exec_func(&self, ctx: &Context, ident: String, args: Vec<Value>, predicate: Option<Program>) -> Result<Value> {
+impl Environment<'_> {
+    pub fn eval_func(&self, ctx: &Context, ident: String, args: Vec<Value>, predicate: Option<Program>) -> Result<Value> {
         let call = ExprCall {
             ident,
             args,
             predicate,
             ctx,
-            parser: self,
+            env: self,
         };
         if let Some(f) = self.functions.get(&call.ident) {
             f(call)

--- a/src/functions/string.rs
+++ b/src/functions/string.rs
@@ -1,7 +1,7 @@
-use crate::{bail, Parser, Value};
+use crate::{bail, Environment, Value};
 
-pub fn add_string_functions(p: &mut Parser) {
-    p.add_function("trim", |c| {
+pub fn add_string_functions(env: &mut Environment) {
+    env.add_function("trim", |c| {
         if c.args.len() != 1 && c.args.len() != 2 {
             bail!("trim() takes one or two arguments");
         }
@@ -14,7 +14,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("trimPrefix", |c| {
+    env.add_function("trimPrefix", |c| {
         if let (Value::String(s), Value::String(prefix)) = (&c.args[0], &c.args[1]) {
             Ok(s.strip_prefix(prefix).unwrap_or(s).into())
         } else {
@@ -22,7 +22,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("trimSuffix", |c| {
+    env.add_function("trimSuffix", |c| {
         if let (Value::String(s), Value::String(suffix)) = (&c.args[0], &c.args[1]) {
             Ok(s.strip_suffix(suffix).unwrap_or(s).into())
         } else {
@@ -30,7 +30,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("upper", |c| {
+    env.add_function("upper", |c| {
         if c.args.len() != 1 {
             bail!("upper() takes one argument");
         }
@@ -41,7 +41,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("lower", |c| {
+    env.add_function("lower", |c| {
         if c.args.len() != 1 {
             bail!("lower() takes one argument");
         }
@@ -52,7 +52,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("split", |c| {
+    env.add_function("split", |c| {
         if let (Value::String(s), Value::String(sep), None) = (&c.args[0], &c.args[1], c.args.get(2)) {
             Ok(s.split(sep).map(Value::from).collect::<Vec<_>>().into())
         } else if let (Value::String(s), Value::String(sep), Some(Value::Number(n))) = (&c.args[0], &c.args[1], c.args.get(2)) {
@@ -62,7 +62,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("splitAfter", |c| {
+    env.add_function("splitAfter", |c| {
         if let (Value::String(s), Value::String(sep), None) = (&c.args[0], &c.args[1], c.args.get(2)) {
             Ok(s.split_inclusive(sep).map(Value::from).collect::<Vec<_>>().into())
         } else if let (Value::String(s), Value::String(sep), Some(Value::Number(n))) = (&c.args[0], &c.args[1], c.args.get(2)) {
@@ -74,7 +74,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("replace", |c| {
+    env.add_function("replace", |c| {
         if let (Value::String(s), Value::String(from), Value::String(to)) =
             (&c.args[0], &c.args[1], &c.args[2])
         {
@@ -84,7 +84,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("repeat", |c| {
+    env.add_function("repeat", |c| {
         if let (Value::String(s), Value::Number(n)) = (&c.args[0], &c.args[1]) {
             Ok(s.repeat(*n as usize + 1).into())
         } else {
@@ -92,7 +92,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("indexOf", |c| {
+    env.add_function("indexOf", |c| {
         if let (Value::String(s), Value::String(sub)) = (&c.args[0], &c.args[1]) {
             Ok(s.find(sub).map(|i| i as i64).unwrap_or(-1).into())
         } else {
@@ -100,7 +100,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("lastIndexOf", |c| {
+    env.add_function("lastIndexOf", |c| {
         if let (Value::String(s), Value::String(sub)) = (&c.args[0], &c.args[1]) {
             Ok(s.rfind(sub).map(|i| i as i64).unwrap_or(-1).into())
         } else {
@@ -108,7 +108,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("hasPrefix", |c| {
+    env.add_function("hasPrefix", |c| {
         if let (Value::String(s), Value::String(prefix)) = (&c.args[0], &c.args[1]) {
             Ok(s.starts_with(prefix).into())
         } else {
@@ -116,7 +116,7 @@ pub fn add_string_functions(p: &mut Parser) {
         }
     });
 
-    p.add_function("hasSuffix", |c| {
+    env.add_function("hasSuffix", |c| {
         if let (Value::String(s), Value::String(suffix)) = (&c.args[0], &c.args[1]) {
             Ok(s.ends_with(suffix).into())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! ```
 mod ast;
 mod context;
+mod eval;
 mod error;
 mod functions;
 mod parser;
@@ -35,6 +36,9 @@ mod value;
 
 pub use crate::context::Context;
 pub use crate::error::{Error, Result};
+pub use crate::eval::{Environment, run, eval};
+pub use crate::parser::compile;
+#[allow(deprecated)]
 pub use crate::parser::Parser;
 pub use crate::ast::program::Program;
 pub use crate::value::Value;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,20 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
-use crate::functions::{array, string, ExprCall, Function};
+use crate::eval::Environment;
+use crate::functions::ExprCall;
 use crate::{ExprPest, Rule};
-use crate::{bail, Context, Error, Result, Value};
-use indexmap::IndexMap;
+use crate::{Context, Error, Result, Value};
 use pest::Parser as PestParser;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+
+/// Parse an expr program to be run later
+pub fn compile(code: &str) -> Result<Program> {
+    #[cfg(debug_assertions)]
+    pest::set_error_detail(true);
+    let pairs = ExprPest::parse(Rule::full, code).map_err(|e| Error::PestError(Box::new(e)))?;
+    Ok(pairs.into())
+}
 
 /// Main struct for parsing and evaluating expr programs
 ///
@@ -18,26 +26,26 @@ use std::fmt::{Debug, Formatter};
 /// let p = Parser::new();
 /// assert_eq!(p.eval("foo + bar", &ctx).unwrap().to_string(), "3");
 /// ```
+#[deprecated(note = "Use `compile()` and `Environment` instead")]
 #[derive(Default)]
 pub struct Parser<'a> {
-    pub(crate) functions: IndexMap<String, Function<'a>>,
+    env: Environment<'a>,
 }
 
+#[allow(deprecated)]
 impl Debug for Parser<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("ExprParser").finish()
     }
 }
 
+#[allow(deprecated)]
 impl<'a> Parser<'a> {
-    /// Create a new parser with default set of functions
+    /// Create a new parser with the default environment
     pub fn new() -> Self {
-        let mut p = Self {
-            functions: IndexMap::new(),
-        };
-        string::add_string_functions(&mut p);
-        array::add_array_functions(&mut p);
-        p
+        Parser {
+            env: Environment::new(),
+        }
     }
 
     /// Add a function for expr programs to call
@@ -66,25 +74,17 @@ impl<'a> Parser<'a> {
     where
         F: Fn(ExprCall) -> Result<Value> + 'a + Sync + Send,
     {
-        self.functions.insert(name.to_string(), Box::new(f));
+        self.env.add_function(name, Box::new(f));
     }
 
     /// Parse an expr program to be run later
     pub fn compile(&self, code: &str) -> Result<Program> {
-        #[cfg(debug_assertions)]
-        pest::set_error_detail(true);
-        let pairs = ExprPest::parse(Rule::full, code).map_err(|e| Error::PestError(Box::new(e)))?;
-        Ok(pairs.into())
+        compile(code)
     }
 
     /// Run a compiled expr program
     pub fn run(&self, program: Program, ctx: &Context) -> Result<Value> {
-        let mut ctx = ctx.clone();
-        ctx.insert("$env".to_string(), Value::Map(ctx.0.clone()));
-        for (id, expr) in program.lines {
-            ctx.insert(id, self.eval_expr(&ctx, expr)?);
-        }
-        self.eval_expr(&ctx, program.expr)
+        self.env.run(program, ctx)
     }
 
     /// Compile and run an expr program in one step
@@ -98,56 +98,10 @@ impl<'a> Parser<'a> {
     /// assert_eq!(p.eval("1 + 2", &ctx).unwrap().to_string(), "3");
     /// ```
     pub fn eval(&self, code: &str, ctx: &Context) -> Result<Value> {
-        let program = self.compile(code)?;
-        self.run(program, ctx)
+        self.env.eval(code, ctx)
     }
 
     pub fn eval_expr(&self, ctx: &Context, node: Node) -> Result<Value> {
-        let value = match node {
-            Node::Value(value) => value,
-            Node::Ident(id) => {
-                if let Some(value) = ctx.get(&id) {
-                    value.clone()
-                } else if let Some(item) = ctx
-                    .get("#")
-                    .and_then(|o| o.as_map())
-                    .and_then(|m| m.get(&id))
-                {
-                    item.clone()
-                } else {
-                    bail!("Unknown variable: {id}")
-                }
-            }
-            Node::Func {
-                ident,
-                args,
-                predicate,
-            } => {
-                let args = args
-                    .into_iter()
-                    .map(|e| self.eval_expr(ctx, e))
-                    .collect::<Result<_>>()?;
-                self.exec_func(ctx, ident, args, predicate.map(|l| *l))?
-            },
-            Node::Operation {
-                left,
-                operator,
-                right,
-            } => self.eval_operator(ctx, operator, *left, *right)?,
-            Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, *node)?,
-            Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, *node)?,
-            Node::Array(a) => Value::Array(
-                a.into_iter()
-                    .map(|e| self.eval_expr(ctx, e))
-                    .collect::<Result<_>>()?,
-            ), // node => bail!("unexpected node: {node:?}"),
-            Node::Range(start, end) => match (self.eval_expr(ctx, *start)?, self.eval_expr(ctx, *end)?) {
-                (Value::Number(start), Value::Number(end)) => {
-                    Value::Array((start..=end).map(Value::Number).collect())
-                }
-                (start, end) => bail!("Invalid range: {start:?}..{end:?}"),
-            }
-        };
-        Ok(value)
+        self.env.eval_expr(ctx, node)
     }
 }


### PR DESCRIPTION
This addresses https://github.com/jdx/expr.rs/issues/6, though instead of adding a `run()` method to `Program` it adds a crate-level function, along with a `run()` method on the new `Environment` struct.

This deprecates `Parser`. All of its functionality is moved to `Environment`, since none of it was related to actual parsing. `Parser` is now a wrapper around `Environment` for backwards compatibility.