### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 ### Bug Fixes
 
 - Support braceless predicates matching Go expr-lang behavior ([#23](https://github.com/jdx/expr.rs/pull/23))
+# Changelog
+
+
+### Bug Fixes
+
+- *(deps)* Update rust crate strum to 0.28 ([#34](https://github.com/jdx/expr.rs/pull/34))
+
+### Miscellaneous
+
+- *(deps)* Lock file maintenance ([#37](https://github.com/jdx/expr.rs/pull/37))
+- *(deps)* Update rust crate indexmap to v2.14.0 ([#38](https://github.com/jdx/expr.rs/pull/38))
+- *(deps)* Lock file maintenance ([#39](https://github.com/jdx/expr.rs/pull/39))
+- *(deps)* Lock file maintenance ([#40](https://github.com/jdx/expr.rs/pull/40))
+- *(deps)* Lock file maintenance ([#41](https://github.com/jdx/expr.rs/pull/41))
+- Set dev profile debug to 1 ([#42](https://github.com/jdx/expr.rs/pull/42))
+
 
 ## [0.4.0] - 2026-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 # Changelog
 
-
-### Bug Fixes
-
-- Support braceless predicates matching Go expr-lang behavior ([#23](https://github.com/jdx/expr.rs/pull/23))
-# Changelog
-
+## [2.0.0] - 2026-08-19
 
 ### Bug Fixes
 
@@ -76,6 +71,11 @@
 
 - Add go expr compatibility corpus ([#85](https://github.com/jdx/expr.rs/pull/85))
 
+## [1.1.1] - 2026-02-10
+
+### Bug Fixes
+
+- Support braceless predicates matching Go expr-lang behavior ([#23](https://github.com/jdx/expr.rs/pull/23))
 
 ## [0.4.0] - 2026-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,78 @@
 ### Bug Fixes
 
 - Support braceless predicates matching Go expr-lang behavior ([#23](https://github.com/jdx/expr.rs/pull/23))
+# Changelog
+
+
+### Bug Fixes
+
+- *(deps)* Update rust crate strum to 0.28 ([#34](https://github.com/jdx/expr.rs/pull/34))
+- *(lib)* Align go compatibility edge cases ([#91](https://github.com/jdx/expr.rs/pull/91))
+- *(deps)* Update rust crate base64 to 0.23 ([#93](https://github.com/jdx/expr.rs/pull/93))
+- *(lib)* Return errors for malformed built-in calls ([#100](https://github.com/jdx/expr.rs/pull/100))
+- *(lib)* Align arithmetic edge cases ([#101](https://github.com/jdx/expr.rs/pull/101))
+- *(parse)* Support dynamic ranges and slices ([#104](https://github.com/jdx/expr.rs/pull/104))
+- *(lib)* Align unicode and collection edge cases ([#105](https://github.com/jdx/expr.rs/pull/105))
+- *(lib)* Align arbitrary map key semantics ([#106](https://github.com/jdx/expr.rs/pull/106))
+- *(lib)* Preserve temporal timezone semantics ([#109](https://github.com/jdx/expr.rs/pull/109))
+
+### Documentation
+
+- Document v2 status and migration ([#80](https://github.com/jdx/expr.rs/pull/80))
+
+### Features
+
+- Add expr conversion built-ins ([#71](https://github.com/jdx/expr.rs/pull/71))
+- *(lib)* Align operators and add bitwise built-ins ([#73](https://github.com/jdx/expr.rs/pull/73))
+- *(lib)* Add borrowed and serializable contexts ([#79](https://github.com/jdx/expr.rs/pull/79))
+- *(parse)* Add go-compatible literal syntax ([#86](https://github.com/jdx/expr.rs/pull/86))
+- *(lib)* Add numeric and utility built-ins ([#87](https://github.com/jdx/expr.rs/pull/87))
+- *(lib)* Add collection utility built-ins ([#88](https://github.com/jdx/expr.rs/pull/88))
+- *(lib)* Add aggregate predicate built-ins ([#89](https://github.com/jdx/expr.rs/pull/89))
+- *(lib)* Add predicate indices and scientific literals ([#94](https://github.com/jdx/expr.rs/pull/94))
+- *(lib)* Add byte values and literals ([#95](https://github.com/jdx/expr.rs/pull/95))
+- *(parse)* Add multiline conditional expressions ([#97](https://github.com/jdx/expr.rs/pull/97))
+- *(lib)* Add temporal values and functions ([#98](https://github.com/jdx/expr.rs/pull/98))
+- *(lib)* Add non-string map keys ([#99](https://github.com/jdx/expr.rs/pull/99))
+- *(lib)* Complete temporal compatibility ([#107](https://github.com/jdx/expr.rs/pull/107))
+
+### Miscellaneous
+
+- *(deps)* Lock file maintenance ([#37](https://github.com/jdx/expr.rs/pull/37))
+- *(deps)* Update rust crate indexmap to v2.14.0 ([#38](https://github.com/jdx/expr.rs/pull/38))
+- *(deps)* Lock file maintenance ([#39](https://github.com/jdx/expr.rs/pull/39))
+- *(deps)* Lock file maintenance ([#40](https://github.com/jdx/expr.rs/pull/40))
+- *(deps)* Lock file maintenance ([#41](https://github.com/jdx/expr.rs/pull/41))
+- Set dev profile debug to 1 ([#42](https://github.com/jdx/expr.rs/pull/42))
+- *(deps)* Lock file maintenance ([#44](https://github.com/jdx/expr.rs/pull/44))
+- *(deps)* Lock file maintenance ([#45](https://github.com/jdx/expr.rs/pull/45))
+- *(deps)* Lock file maintenance ([#46](https://github.com/jdx/expr.rs/pull/46))
+- *(deps)* Lock file maintenance lockfile maintenance ([#49](https://github.com/jdx/expr.rs/pull/49))
+- *(deps)* Lock file maintenance lockfile maintenance ([#51](https://github.com/jdx/expr.rs/pull/51))
+- *(deps)* Lock file maintenance lockfile maintenance ([#53](https://github.com/jdx/expr.rs/pull/53))
+- *(deps)* Lock file maintenance ([#55](https://github.com/jdx/expr.rs/pull/55))
+- *(deps)* Lock file maintenance ([#56](https://github.com/jdx/expr.rs/pull/56))
+- *(deps)* Update rust crate regex to v1.13.1 ([#60](https://github.com/jdx/expr.rs/pull/60))
+- *(deps)* Update rust crate serde_json to v1.0.151 ([#64](https://github.com/jdx/expr.rs/pull/64))
+- *(deps)* Update rust crate thiserror to v2.0.19 ([#65](https://github.com/jdx/expr.rs/pull/65))
+- *(deps)* Update rust crate serde to v1.0.229 ([#63](https://github.com/jdx/expr.rs/pull/63))
+- *(deps)* Update rust crate pest_derive to v2.8.8 ([#67](https://github.com/jdx/expr.rs/pull/67))
+- *(deps)* Lock file maintenance ([#68](https://github.com/jdx/expr.rs/pull/68))
+- Harden v2 release checks ([#92](https://github.com/jdx/expr.rs/pull/92))
+
+### Performance
+
+- *(lib)* Borrow compiled programs during evaluation ([#75](https://github.com/jdx/expr.rs/pull/75))
+- *(parse)* Precompile literal regexes ([#77](https://github.com/jdx/expr.rs/pull/77))
+
+### Refactor
+
+- *(lib)* Rename number value to integer ([#72](https://github.com/jdx/expr.rs/pull/72))
+
+### Testing
+
+- Add go expr compatibility corpus ([#85](https://github.com/jdx/expr.rs/pull/85))
+
 
 ## [0.4.0] - 2026-01-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "expr-lang"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "expr-lang"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expr-lang"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 authors = ["@jdx"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expr-lang"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["@jdx"]


### PR DESCRIPTION



## 🤖 New release

* `expr-lang`: 1.1.1 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `expr-lang` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Rule::predicate 10 -> 11 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::term 11 -> 12 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::ternary 12 -> 19 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::membership_op 13 -> 20 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::opt_membership_op 14 -> 21 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::opt_index_op 15 -> 22 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::default_op 16 -> 23 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::index_op 17 -> 24 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::range_start_op 18 -> 25 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::range_end_op 19 -> 26 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::negation_op 20 -> 27 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::sign_op 21 -> 28 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::exponent_op 22 -> 29 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::multiplication_op 23 -> 30 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::addition_op 24 -> 31 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::comparison_op 25 -> 33 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::equal_op 26 -> 34 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::and_op 27 -> 35 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::or_op 28 -> 36 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::string_op 29 -> 37 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::value 30 -> 38 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::array 31 -> 39 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::map 32 -> 40 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::string 34 -> 42 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::string_multiline 35 -> 44 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::inner_single 36 -> 45 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::inner_double 37 -> 46 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::inner_multiline 38 -> 49 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::int 39 -> 50 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::bool 40 -> 51 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::nil 41 -> 52 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::decimal 42 -> 53 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::ident 43 -> 57 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::char_single 44 -> 58 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::char_double 45 -> 59 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::LINE_COMMENT 46 -> 62 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::BLOCK_COMMENT 47 -> 63 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::COMMENT 48 -> 64 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule::WHITESPACE 49 -> 65 in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Rule:method_call in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:conditional_if in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:if_keyword in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:else_keyword in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:if_identifier_prefix in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:else_identifier_prefix in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:block in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:range_op in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:map_key in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:bytes in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:inner_bytes_single in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:inner_bytes_double in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:decimal_digits in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:exponent in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:not_in_op in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:char_bytes_single in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Rule:char_bytes_double in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  variant Value:Integer in /tmp/.tmpIjer1m/expr.rs/src/value.rs:248
  variant Value:DateTime in /tmp/.tmpIjer1m/expr.rs/src/value.rs:254
  variant Value:Duration in /tmp/.tmpIjer1m/expr.rs/src/value.rs:255
  variant Value:Timezone in /tmp/.tmpIjer1m/expr.rs/src/value.rs:256
  variant Value:Month in /tmp/.tmpIjer1m/expr.rs/src/value.rs:257
  variant Value:Weekday in /tmp/.tmpIjer1m/expr.rs/src/value.rs:258
  variant Value:Bytes in /tmp/.tmpIjer1m/expr.rs/src/value.rs:261
  variant Value:KeyedMap in /tmp/.tmpIjer1m/expr.rs/src/value.rs:264

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Rule::range, previously in file /tmp/.tmpGbHlru/expr-lang/src/lib.rs:52
  variant Value::Number, previously in file /tmp/.tmpGbHlru/expr-lang/src/value.rs:15

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Value::as_number, previously in file /tmp/.tmpGbHlru/expr-lang/src/value.rs:33

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  expr::Environment::eval_operator takes 4 parameters in /tmp/.tmpGbHlru/expr-lang/src/ast/operator.rs:62, but now takes 5 parameters in /tmp/.tmpIjer1m/expr.rs/src/ast/operator.rs:110

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Rule::predicate moved from position 11 to 12, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::term moved from position 12 to 13, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::ternary moved from position 13 to 20, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::membership_op moved from position 14 to 21, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::opt_membership_op moved from position 15 to 22, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::opt_index_op moved from position 16 to 23, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::default_op moved from position 17 to 24, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::index_op moved from position 18 to 25, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::range_start_op moved from position 19 to 26, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::range_end_op moved from position 20 to 27, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::negation_op moved from position 21 to 28, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::sign_op moved from position 22 to 29, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::exponent_op moved from position 23 to 30, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::multiplication_op moved from position 24 to 31, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::addition_op moved from position 25 to 32, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::comparison_op moved from position 26 to 34, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::equal_op moved from position 27 to 35, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::and_op moved from position 28 to 36, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::or_op moved from position 29 to 37, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::string_op moved from position 30 to 38, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::value moved from position 31 to 39, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::array moved from position 32 to 40, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::map moved from position 33 to 41, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::string moved from position 35 to 43, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::string_multiline moved from position 36 to 45, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::inner_single moved from position 37 to 46, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::inner_double moved from position 38 to 47, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::inner_multiline moved from position 39 to 50, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::int moved from position 40 to 51, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::bool moved from position 41 to 52, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::nil moved from position 42 to 53, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::decimal moved from position 43 to 54, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::ident moved from position 44 to 58, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::char_single moved from position 45 to 59, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::char_double moved from position 46 to 60, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::LINE_COMMENT moved from position 47 to 63, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::BLOCK_COMMENT moved from position 48 to 64, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::COMMENT moved from position 49 to 65, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
  Rule::WHITESPACE moved from position 50 to 66, in /tmp/.tmpIjer1m/expr.rs/src/lib.rs:52
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0] - 2026-01-25

### 🚀 Features

- Add JSON and utility functions (#18)

### ⚙️ Miscellaneous Tasks

- Add renovate config (#19)
- Add CLAUDE.md for Claude Code guidance
- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates version metadata and the changelog; runtime behavior changes ship in prior merged PRs already listed in the release notes.
> 
> **Overview**
> **Publishes `expr-lang` 2.0.0** by bumping the crate version in `Cargo.toml` and `Cargo.lock` from **1.1.1** to **2.0.0**.
> 
> Adds a **2.0.0** section to `CHANGELOG.md` that records the accumulated v2 work since 1.1.1 (Go expr alignment, new builtins, temporal/bytes/map-key support, parser extensions, performance fixes, and migration docs)—without changing library source in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafb8ea77fd0c4999141b8a344bec6708b04a019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->