### PR TITLE
feat: add expr conversion built-ins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,9 @@
 git-cliff = "latest"
 watchexec = "latest"
 
+[settings]
+cargo.binstall_native = true
+
 [tasks.lint]
 run = [
   "cargo clippy",

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,8 +1,8 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
-use crate::functions::{array, json, string, ExprCall, Function};
-use crate::{bail, Context, Result, Value};
+use crate::functions::{ExprCall, Function, array, convert, json, string};
 use crate::parser::compile;
+use crate::{Context, Result, Value, bail};
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use std::fmt;
@@ -66,6 +66,7 @@ impl<'a> Environment<'a> {
         };
         string::add_string_functions(&mut p);
         array::add_array_functions(&mut p);
+        convert::add_conversion_functions(&mut p);
         json::add_json_functions(&mut p);
         p
     }

--- a/src/functions/convert.rs
+++ b/src/functions/convert.rs
@@ -1,4 +1,4 @@
-use crate::{bail, Environment, Value};
+use crate::{Environment, Value, bail};
 
 fn one_arg(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
     if args.len() != 1 {
@@ -10,10 +10,72 @@ fn one_arg(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
     Ok(args.pop().expect("length checked"))
 }
 
+fn go_float_string(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+    if value == f64::INFINITY {
+        return "+Inf".to_string();
+    }
+    if value == f64::NEG_INFINITY {
+        return "-Inf".to_string();
+    }
+
+    let rendered = value.to_string();
+    let (sign, unsigned) = rendered
+        .strip_prefix('-')
+        .map_or(("", rendered.as_str()), |value| ("-", value));
+    let (mantissa, explicit_exponent) = unsigned
+        .split_once(['e', 'E'])
+        .map_or((unsigned, 0), |(mantissa, exponent)| {
+            (mantissa, exponent.parse::<i32>().expect("valid exponent"))
+        });
+    let decimal_point = mantissa.find('.').unwrap_or(mantissa.len()) as i32;
+    let mut digits = mantissa.replace('.', "");
+    let leading_zeroes = digits.len() - digits.trim_start_matches('0').len();
+    digits.drain(..leading_zeroes);
+
+    if digits.is_empty() {
+        return format!("{sign}0");
+    }
+
+    let exponent = decimal_point - leading_zeroes as i32 - 1 + explicit_exponent;
+    while digits.ends_with('0') {
+        digits.pop();
+    }
+
+    if !(-4..6).contains(&exponent) {
+        let mut output = format!("{sign}{}", &digits[..1]);
+        if digits.len() > 1 {
+            output.push('.');
+            output.push_str(&digits[1..]);
+        }
+        output.push('e');
+        output.push(if exponent < 0 { '-' } else { '+' });
+        output.push_str(&format!("{:02}", exponent.abs()));
+        return output;
+    }
+
+    if exponent < 0 {
+        format!("{sign}0.{}{digits}", "0".repeat((-exponent - 1) as usize))
+    } else {
+        let decimal_point = exponent as usize + 1;
+        if decimal_point >= digits.len() {
+            format!("{sign}{digits}{}", "0".repeat(decimal_point - digits.len()))
+        } else {
+            format!(
+                "{sign}{}.{}",
+                &digits[..decimal_point],
+                &digits[decimal_point..]
+            )
+        }
+    }
+}
+
 fn expr_string(value: &Value) -> String {
     match value {
         Value::Number(value) => value.to_string(),
-        Value::Float(value) => value.to_string(),
+        Value::Float(value) => go_float_string(*value),
         Value::Bool(value) => value.to_string(),
         Value::Nil => "<nil>".to_string(),
         Value::String(value) => value.clone(),
@@ -23,11 +85,15 @@ fn expr_string(value: &Value) -> String {
         ),
         Value::Map(values) => format!(
             "map[{}]",
-            values
-                .iter()
-                .map(|(key, value)| format!("{key}:{}", expr_string(value)))
-                .collect::<Vec<_>>()
-                .join(" ")
+            {
+                let mut values = values.iter().collect::<Vec<_>>();
+                values.sort_unstable_by_key(|(key, _)| key.as_str());
+                values
+            }
+            .into_iter()
+            .map(|(key, value)| format!("{key}:{}", expr_string(value)))
+            .collect::<Vec<_>>()
+            .join(" ")
         ),
     }
 }
@@ -62,7 +128,8 @@ pub fn add_conversion_functions(env: &mut Environment) {
 
 #[cfg(test)]
 mod tests {
-    use crate::{eval, Context, Value};
+    use super::expr_string;
+    use crate::{Context, Value, eval};
 
     #[test]
     fn conversion_builtins_match_expr() {
@@ -94,5 +161,28 @@ mod tests {
         assert!(eval("int(1, 2)", &context).is_err());
         assert!(eval(r#"int("five")"#, &context).is_err());
         assert!(eval(r#"float("five")"#, &context).is_err());
+    }
+
+    #[test]
+    fn string_matches_go_float_formatting() {
+        let cases = [
+            (f64::NAN, "NaN"),
+            (f64::INFINITY, "+Inf"),
+            (f64::NEG_INFINITY, "-Inf"),
+            (1e-4, "0.0001"),
+            (1e-5, "1e-05"),
+            (1e6, "1e+06"),
+            (1e20, "1e+20"),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(expr_string(&Value::Float(value)), expected);
+        }
+    }
+
+    #[test]
+    fn string_sorts_map_keys_like_go() {
+        let value = [("c", 3), ("b", 2), ("a", 1)].into_iter().collect();
+        assert_eq!(expr_string(&value), "map[a:1 b:2 c:3]");
     }
 }

--- a/src/functions/convert.rs
+++ b/src/functions/convert.rs
@@ -1,0 +1,98 @@
+use crate::{bail, Environment, Value};
+
+fn one_arg(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
+    if args.len() != 1 {
+        bail!(
+            "invalid number of arguments for {name} (expected 1, got {})",
+            args.len()
+        );
+    }
+    Ok(args.pop().expect("length checked"))
+}
+
+fn expr_string(value: &Value) -> String {
+    match value {
+        Value::Number(value) => value.to_string(),
+        Value::Float(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Nil => "<nil>".to_string(),
+        Value::String(value) => value.clone(),
+        Value::Array(values) => format!(
+            "[{}]",
+            values.iter().map(expr_string).collect::<Vec<_>>().join(" ")
+        ),
+        Value::Map(values) => format!(
+            "map[{}]",
+            values
+                .iter()
+                .map(|(key, value)| format!("{key}:{}", expr_string(value)))
+                .collect::<Vec<_>>()
+                .join(" ")
+        ),
+    }
+}
+
+/// Add expr's built-in conversion functions.
+pub fn add_conversion_functions(env: &mut Environment) {
+    env.add_function("int", |call| match one_arg("int", call.args)? {
+        Value::Number(value) => Ok(value.into()),
+        Value::Float(value) => Ok((value as i64).into()),
+        Value::String(value) => value
+            .parse::<i64>()
+            .map(Value::Number)
+            .map_err(|_| format!("invalid operation: int({value})").into()),
+        value => bail!("invalid operation: int({})", expr_string(&value)),
+    });
+
+    env.add_function("float", |call| match one_arg("float", call.args)? {
+        Value::Number(value) => Ok((value as f64).into()),
+        Value::Float(value) => Ok(value.into()),
+        Value::String(value) => value
+            .parse::<f64>()
+            .map(Value::Float)
+            .map_err(|_| format!("invalid operation: float({value})").into()),
+        value => bail!("invalid operation: float({})", expr_string(&value)),
+    });
+
+    env.add_function("string", |call| {
+        let value = one_arg("string", call.args)?;
+        Ok(expr_string(&value).into())
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{eval, Context, Value};
+
+    #[test]
+    fn conversion_builtins_match_expr() {
+        let context = Context::default();
+        let cases = [
+            ("int(5.5)", Value::Number(5)),
+            ("int(5)", Value::Number(5)),
+            (r#"int("5")"#, Value::Number(5)),
+            ("float(5)", Value::Float(5.0)),
+            ("float(5.5)", Value::Float(5.5)),
+            (r#"float("5.5")"#, Value::Float(5.5)),
+            ("string(5)", Value::String("5".to_string())),
+            ("string(5.5)", Value::String("5.5".to_string())),
+            (
+                r#"string("already text")"#,
+                Value::String("already text".to_string()),
+            ),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(eval(code, &context).unwrap(), expected, "{code}");
+        }
+    }
+
+    #[test]
+    fn conversions_report_invalid_input() {
+        let context = Context::default();
+        assert!(eval("int()", &context).is_err());
+        assert!(eval("int(1, 2)", &context).is_err());
+        assert!(eval(r#"int("five")"#, &context).is_err());
+        assert!(eval(r#"float("five")"#, &context).is_err());
+    }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,6 +1,7 @@
-pub mod string;
 pub mod array;
+pub mod convert;
 pub mod json;
+pub mod string;
 
 use crate::Result;
 


### PR DESCRIPTION
Adds the original expr conversion built-ins needed by portable consumers:

- `int` converts integers, floats, and numeric strings
- `float` converts integers, floats, and numeric strings
- `string` applies Go-compatible formatting to expr values

This lets Rust expressions use the same `int(value)` contract as `expr-lang/expr`, which is required for cross-runtime validation of raw CLI values.

Validation:

- `cargo test` (96 unit tests, 10 doctests)
- `cargo clippy --lib --all-features -- -A clippy::useless_borrows_in_formatting -D warnings`
- `rustfmt --check src/functions/convert.rs`
- `git diff --check`

Repository-wide strict clippy still reports pre-existing warnings in `ast/node.rs`, `value.rs`, `serde.rs`, and macro tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive builtins and tests only; no changes to auth, persistence, or existing eval paths beyond registering new functions.
> 
> **Overview**
> Adds **Go-compatible conversion builtins** to the default evaluation environment: `int`, `float`, and `string`, wired through a new `convert` module and registered in `Environment::new`.
> 
> `int` and `float` accept numbers, floats, and parseable numeric strings; other types get `invalid operation` errors that use Go-style value rendering. `string` formats all value kinds (including special float cases like `NaN`/`±Inf`, scientific notation rules, and sorted `map[...]` output) so Rust expressions can match `expr-lang/expr` for cross-runtime checks.
> 
> Also enables `cargo.binstall_native` in `mise.toml` and includes unit tests for conversions, errors, and string formatting parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe7bf2b98869acfa61b6c4905fb1d48577fee80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in `int`, `float`, and `string` conversion functions.
  * Conversions now support validating input types and provide clear error messages for invalid values.
  * Conversion functions are available in the default evaluation environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->