### PR TITLE
feat(lib)!: align operators and add bitwise built-ins

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,10 +1,10 @@
 use crate::ast::node::Node;
-use crate::Value::{Array, Bool, Float, Map, Integer, String};
+use crate::Value::{Array, Bool, Float, Integer, Map, String};
 use crate::{bail, Result, Rule};
 use crate::{Context, Environment, Value};
-use pest::iterators::{Pair};
-use std::str::FromStr;
 use log::trace;
+use pest::iterators::Pair;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, strum::EnumString, strum::Display)]
 pub enum Operator {
@@ -58,6 +58,29 @@ impl From<Pair<'_, Rule>> for Operator {
     }
 }
 
+fn values_equal(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Integer(left), Float(right)) => *left as f64 == *right,
+        (Float(left), Integer(right)) => *left == *right as f64,
+        (Array(left), Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| values_equal(left, right))
+        }
+        (Map(left), Map(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(key, left)| {
+                    right
+                        .get(key)
+                        .is_some_and(|right| values_equal(left, right))
+                })
+        }
+        _ => left == right,
+    }
+}
+
 impl Environment<'_> {
     pub fn eval_operator(
         &self,
@@ -67,74 +90,120 @@ impl Environment<'_> {
         right: Node,
     ) -> Result<Value> {
         let left = self.eval_expr(ctx, left)?;
+        match &operator {
+            Operator::And => {
+                return match left {
+                    Bool(false) => Ok(Bool(false)),
+                    Bool(true) => match self.eval_expr(ctx, right)? {
+                        Bool(value) => Ok(Bool(value)),
+                        _ => bail!("Invalid operands for operator {operator}"),
+                    },
+                    _ => bail!("Invalid operands for operator {operator}"),
+                };
+            }
+            Operator::Or => {
+                return match left {
+                    Bool(true) => Ok(Bool(true)),
+                    Bool(false) => match self.eval_expr(ctx, right)? {
+                        Bool(value) => Ok(Bool(value)),
+                        _ => bail!("Invalid operands for operator {operator}"),
+                    },
+                    _ => bail!("Invalid operands for operator {operator}"),
+                };
+            }
+            _ => {}
+        }
         let right = self.eval_expr(ctx, right)?;
         let result = match operator {
             Operator::Add => match (left, right) {
                 (Integer(left), Integer(right)) => (left + right).into(),
                 (Float(left), Float(right)) => (left + right).into(),
+                (Integer(left), Float(right)) => Float(left as f64 + right),
+                (Float(left), Integer(right)) => Float(left + right as f64),
                 (String(left), String(right)) => format!("{left}{right}").into(),
                 _ => bail!("Invalid operands for operator +"),
             },
             Operator::Subtract => match (left, right) {
                 (Integer(left), Integer(right)) => Integer(left - right),
                 (Float(left), Float(right)) => Float(left - right),
+                (Integer(left), Float(right)) => Float(left as f64 - right),
+                (Float(left), Integer(right)) => Float(left - right as f64),
                 _ => bail!("Invalid operands for operator -"),
             },
             Operator::Multiply => match (left, right) {
                 (Integer(left), Integer(right)) => Integer(left * right),
                 (Float(left), Float(right)) => Float(left * right),
+                (Integer(left), Float(right)) => Float(left as f64 * right),
+                (Float(left), Integer(right)) => Float(left * right as f64),
                 _ => bail!("Invalid operands for operator *"),
             },
             Operator::Divide => match (left, right) {
                 (Integer(left), Integer(right)) => Integer(left / right),
                 (Float(left), Float(right)) => Float(left / right),
+                (Integer(left), Float(right)) => Float(left as f64 / right),
+                (Float(left), Integer(right)) => Float(left / right as f64),
                 _ => bail!("Invalid operands for operator /"),
             },
             Operator::Modulo => match (left, right) {
-                    (Integer(left), Integer(right)) => Integer(left % right),
-                    _ => bail!("Invalid operands for operator %"),
-                },
+                (Integer(left), Integer(right)) => Integer(left % right),
+                _ => bail!("Invalid operands for operator %"),
+            },
             Operator::Pow => match (left, right) {
                 (Integer(left), Integer(right)) => Integer(left.pow(right as u32)),
                 (Float(left), Float(right)) => Float(left.powf(right)),
+                (Integer(left), Float(right)) => Float((left as f64).powf(right)),
+                (Float(left), Integer(right)) => Float(left.powf(right as f64)),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
-            Operator::Equal => Bool(left == right),
-            Operator::NotEqual => Bool(left != right),
+            Operator::Equal => Bool(values_equal(&left, &right)),
+            Operator::NotEqual => Bool(!values_equal(&left, &right)),
             Operator::GreaterThan => match (left, right) {
                 (Integer(left), Integer(right)) => (left > right).into(),
                 (Float(left), Float(right)) => (left > right).into(),
+                (Integer(left), Float(right)) => (left as f64 > right).into(),
+                (Float(left), Integer(right)) => (left > right as f64).into(),
                 (String(left), String(right)) => (left > right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::GreaterThanOrEqual => match (left, right) {
                 (Integer(left), Integer(right)) => (left >= right).into(),
                 (Float(left), Float(right)) => (left >= right).into(),
+                (Integer(left), Float(right)) => (left as f64 >= right).into(),
+                (Float(left), Integer(right)) => (left >= right as f64).into(),
                 (String(left), String(right)) => (left >= right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::LessThan => match (left, right) {
                 (Integer(left), Integer(right)) => (left < right).into(),
                 (Float(left), Float(right)) => (left < right).into(),
+                (Integer(left), Float(right)) => ((left as f64) < right).into(),
+                (Float(left), Integer(right)) => (left < right as f64).into(),
                 (String(left), String(right)) => (left < right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::LessThanOrEqual => match (left, right) {
                 (Integer(left), Integer(right)) => (left <= right).into(),
                 (Float(left), Float(right)) => (left <= right).into(),
+                (Integer(left), Float(right)) => (left as f64 <= right).into(),
+                (Float(left), Integer(right)) => (left <= right as f64).into(),
                 (String(left), String(right)) => (left <= right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
-            Operator::And => Bool(left.as_bool() == Some(true) && right.as_bool() == Some(true)),
-            Operator::Or => Bool(left.as_bool() == Some(true) || right.as_bool() == Some(true)),
+            Operator::And | Operator::Or => unreachable!("handled before evaluating right operand"),
             Operator::In => match (left, right) {
                 (String(left), Map(right)) => right.contains_key(&left).into(),
-                (left, Array(right)) => right.contains(&left).into(),
+                (left, Array(right)) => right
+                    .iter()
+                    .any(|right| values_equal(&left, right))
+                    .into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::Contains => match (left, right) {
                 (String(left), String(right)) => left.contains(&right).into(),
-                (Array(left), right) => left.contains(&right).into(),
+                (Array(left), right) => left
+                    .iter()
+                    .any(|left| values_equal(left, &right))
+                    .into(),
                 (Map(left), String(right)) => left.contains_key(&right).into(),
                 _ => bail!("Invalid operands for operator contains"),
             },
@@ -154,7 +223,7 @@ impl Environment<'_> {
                 _ => bail!("Invalid operands for operator matches"),
             },
         };
-        
+
         Ok(result)
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,6 +1,6 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
-use crate::functions::{ExprCall, Function, array, convert, json, string};
+use crate::functions::{ExprCall, Function, array, bitwise, convert, json, string};
 use crate::parser::compile;
 use crate::{Context, Result, Value, bail};
 use indexmap::IndexMap;
@@ -66,6 +66,7 @@ impl<'a> Environment<'a> {
         };
         string::add_string_functions(&mut p);
         array::add_array_functions(&mut p);
+        bitwise::add_bitwise_functions(&mut p);
         convert::add_conversion_functions(&mut p);
         json::add_json_functions(&mut p);
         p

--- a/src/functions/bitwise.rs
+++ b/src/functions/bitwise.rs
@@ -1,0 +1,120 @@
+use crate::{bail, Environment, Value};
+
+fn one_integer(name: &str, mut args: Vec<Value>) -> crate::Result<i64> {
+    if args.len() != 1 {
+        bail!(
+            "invalid number of arguments for {name} (expected 1, got {})",
+            args.len()
+        );
+    }
+    match args.pop().expect("length checked") {
+        Value::Integer(value) => Ok(value),
+        _ => bail!("invalid argument for {name} (expected integer)"),
+    }
+}
+
+fn two_integers(name: &str, args: Vec<Value>) -> crate::Result<(i64, i64)> {
+    if args.len() != 2 {
+        bail!(
+            "invalid number of arguments for {name} (expected 2, got {})",
+            args.len()
+        );
+    }
+    let mut args = args.into_iter();
+    match (
+        args.next().expect("length checked"),
+        args.next().expect("length checked"),
+    ) {
+        (Value::Integer(left), Value::Integer(right)) => Ok((left, right)),
+        _ => bail!("invalid arguments for {name} (expected integers)"),
+    }
+}
+
+fn shift_count(count: i64) -> crate::Result<u32> {
+    if count < 0 {
+        bail!("invalid operation: negative shift count {count} (type integer)");
+    }
+    Ok(u32::try_from(count).unwrap_or(u32::MAX))
+}
+
+/// Add expr's built-in bitwise functions.
+pub fn add_bitwise_functions(env: &mut Environment) {
+    env.add_function("bitand", |call| {
+        let (left, right) = two_integers("bitand", call.args)?;
+        Ok(Value::Integer(left & right))
+    });
+    env.add_function("bitor", |call| {
+        let (left, right) = two_integers("bitor", call.args)?;
+        Ok(Value::Integer(left | right))
+    });
+    env.add_function("bitxor", |call| {
+        let (left, right) = two_integers("bitxor", call.args)?;
+        Ok(Value::Integer(left ^ right))
+    });
+    env.add_function("bitnand", |call| {
+        let (left, right) = two_integers("bitnand", call.args)?;
+        Ok(Value::Integer(left & !right))
+    });
+    env.add_function("bitnot", |call| {
+        Ok(Value::Integer(!one_integer("bitnot", call.args)?))
+    });
+    env.add_function("bitshl", |call| {
+        let (value, count) = two_integers("bitshl", call.args)?;
+        let count = shift_count(count)?;
+        Ok(Value::Integer(value.checked_shl(count).unwrap_or(0)))
+    });
+    env.add_function("bitshr", |call| {
+        let (value, count) = two_integers("bitshr", call.args)?;
+        let count = shift_count(count)?;
+        let shifted = value
+            .checked_shr(count)
+            .unwrap_or(if value < 0 { -1 } else { 0 });
+        Ok(Value::Integer(shifted))
+    });
+    env.add_function("bitushr", |call| {
+        let (value, count) = two_integers("bitushr", call.args)?;
+        let count = shift_count(count)?;
+        Ok(Value::Integer(
+            (value as u64).checked_shr(count).unwrap_or(0) as i64,
+        ))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{eval, Context, Value};
+
+    #[test]
+    fn bitwise_builtins_match_expr() {
+        let context = Context::default();
+        let cases = [
+            ("bitnot(156)", -157),
+            ("bitand(bitnot(156), 255)", 99),
+            ("bitor(987, -123)", -33),
+            ("bitxor(15, 32)", 47),
+            ("bitshl(39, 3)", 312),
+            ("bitshr(5, 1)", 2),
+            ("bitushr(-5, 2)", 4_611_686_018_427_387_902),
+            ("bitnand(35, 9)", 34),
+            ("bitshl(1, 64)", 0),
+            ("bitshr(-5, 64)", -1),
+            ("bitushr(-5, 64)", 0),
+            ("bitshl(1, 4294967296)", 0),
+            ("bitshr(-5, 4294967296)", -1),
+            ("bitushr(-5, 4294967296)", 0),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(eval(code, &context).unwrap(), Value::Integer(expected));
+        }
+    }
+
+    #[test]
+    fn bitwise_builtins_reject_invalid_arguments() {
+        let context = Context::default();
+        assert!(eval("bitnot()", &context).is_err());
+        assert!(eval("bitand(1)", &context).is_err());
+        assert!(eval("bitand(1, 2.0)", &context).is_err());
+        assert!(eval("bitshl(1, -1)", &context).is_err());
+    }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,4 +1,5 @@
 pub mod array;
+pub mod bitwise;
 pub mod convert;
 pub mod json;
 pub mod string;

--- a/src/test.rs
+++ b/src/test.rs
@@ -61,6 +61,36 @@ fn arithmetic() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn mixed_integer_float_operators() -> Result<()> {
+    test_old!("1 + 0.5", "1.5");
+    test_old!("1.5 - 1", "0.5");
+    test_old!("2 * 0.5", "1");
+    test_old!("1.0 / 2", "0.5");
+    test_old!("2 ** 0.5", "1.4142135623730951");
+    test_old!("1 > 0.5", "true");
+    test_old!("1 >= 1.0", "true");
+    test_old!("1 < 1.5", "true");
+    test_old!("1 <= 1.0", "true");
+    test_old!("1 == 1.0", "true");
+    test_old!("1 != 1.0", "false");
+    test_old!("1 in [1.0]", "true");
+    test_old!("[1.0] contains 1", "true");
+    test_old!("[1] == [1.0]", "true");
+    test_old!("{a: 1} == {a: 1.0}", "true");
+    Ok(())
+}
+
+#[test]
+fn logical_operators_are_strict_and_short_circuit() -> Result<()> {
+    let context = Context::default();
+    assert!(eval("true and 1", &context).is_err());
+    assert!(eval("1 or true", &context).is_err());
+    assert_eq!(eval("false and unknown", &context)?, Value::Bool(false));
+    assert_eq!(eval("true or unknown", &context)?, Value::Bool(true));
+    Ok(())
+}
+
 test!(order_of_ops, "1 + 2 * 3 + 1", "8");
 test!(is_true, "true", "true");
 test!(not_1, "!true", "false");


### PR DESCRIPTION
## Summary

- promote mixed integer/float arithmetic, comparisons, and equality to floating-point semantics
- make `and`/`or` strict boolean operators with short-circuit evaluation
- add the Go expr-compatible `bitand`, `bitor`, `bitxor`, `bitnand`, `bitnot`, `bitshl`, `bitshr`, and `bitushr` built-ins
- cover normal, invalid, negative, and oversized shift behavior

## Why

This moves v2 toward explicit Go expr compatibility and resolves the remaining operator gaps identified in the issue tracker.

## Stack

- built on #72; merge that PR first

## Checks

- `cargo test --all-features` (106 unit tests, 10 doctests)
- `git diff --check`
- `cargo clippy --all-features -- -D warnings` reaches only two pre-existing `useless_borrows_in_formatting` warnings in `src/ast/node.rs` and `src/value.rs`

Fixed #11.
Fixed #12.
Fixed #13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking changes to `and`/`or` and equality/`in`/`contains` can alter existing expressions; core eval paths are extended but localized to `eval_operator` and new functions.
> 
> **Overview**
> Aligns expression evaluation with Go **expr** semantics and closes operator gaps via **breaking** behavior changes and new builtins.
> 
> **Operators:** Mixed **integer/float** operands now work for `+`, `-`, `*`, `/`, `**`, and ordering/equality (numeric paths promote to float). **`==` / `!=`**, **`in`**, and **`contains`** use a new `values_equal` helper so nested arrays/maps compare with int/float equivalence (e.g. `[1] == [1.0]`). **`and` / `or`** require **bool** operands, **short-circuit** (right side skipped when result is fixed), and error on non-booleans instead of truthiness coercion.
> 
> **Builtins:** Registers Go-compatible **`bitand`**, **`bitor`**, **`bitxor`**, **`bitnand`**, **`bitnot`**, **`bitshl`**, **`bitshr`**, **`bitushr`** on the default environment, with integer-only args, rejected negative shifts, and saturated shift counts for oversized values.
> 
> Tests cover mixed numeric ops, strict logical short-circuit, and bitwise cases including edge shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0588fdca61da5fe3bfb0f1fcd8bd15069f365f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->