### PR TITLE
perf(bench): add tak performance tracking

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,47 @@
+name: Perf
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  measure:
+    name: Measure
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
+        with:
+          cache: false
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends valgrind
+      - name: Measure and record
+        run: mise run perf:record
+      - name: Push measurements
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"

--- a/examples/expr-bench.rs
+++ b/examples/expr-bench.rs
@@ -1,0 +1,51 @@
+use expr::{Context, Value, compile, run};
+use indexmap::IndexMap;
+use std::hint::black_box;
+
+fn main() {
+    match std::env::args().nth(1).as_deref() {
+        Some("startup") => {}
+        Some("context") => context(),
+        Some("predicate") => predicate(),
+        Some("regex") => regex(),
+        Some("json") => json(),
+        scenario => panic!("unknown benchmark scenario: {scenario:?}"),
+    }
+}
+
+fn context() {
+    let ctx = Context::from_iter((0..10_000).map(|i| (format!("key_{i}"), i)));
+    let program = compile("key_9999 + 1").unwrap();
+    for _ in 0..100 {
+        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+    }
+}
+
+fn predicate() {
+    let items = (0..500).map(Value::Integer).collect::<Vec<_>>();
+    let ctx = Context::from_iter([("items", Value::Array(items))]);
+    let program = compile("map(items, {# + 1})").unwrap();
+    for _ in 0..10 {
+        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+    }
+}
+
+fn regex() {
+    let ctx = Context::default();
+    let program =
+        compile(r#""release-2.0.0" matches "^release-[0-9]+\\.[0-9]+\\.[0-9]+$""#).unwrap();
+    for _ in 0..10_000 {
+        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+    }
+}
+
+fn json() {
+    let payload = (0..1_000)
+        .map(|i| (format!("key_{i}"), Value::Integer(i)))
+        .collect::<IndexMap<_, _>>();
+    let ctx = Context::from_iter([("payload", Value::Map(payload))]);
+    let program = compile("toJSON(payload)").unwrap();
+    for _ in 0..100 {
+        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 "cargo:pest_fmt" = "latest"
 git-cliff = "latest"
 watchexec = "latest"
+"github:jdx/tak" = "0.0.5"
 
 [settings]
 cargo.binstall_native = true
@@ -17,6 +18,18 @@ run = [
 alias = "t"
 depends = ["lint"]
 run = "cargo test"
+
+[tasks.perf]
+run = [
+  "cargo build --release --example expr-bench",
+  "tak run",
+]
+
+[tasks."perf:record"]
+run = [
+  "cargo build --release --example expr-bench",
+  "tak run --record",
+]
 
 [tasks.release]
 run = [

--- a/tak.toml
+++ b/tak.toml
@@ -1,0 +1,27 @@
+# Instruction-counted benchmarks for the evaluator's major hot paths.
+#
+# The benchmark binary performs fixed, hermetic work. Building happens outside
+# the measured command so compilation cannot affect the results.
+
+[gate]
+pct = 1.0
+
+[bench.startup]
+cmd = ["./target/release/examples/expr-bench", "startup"]
+runs = 10
+
+[bench.context]
+cmd = ["./target/release/examples/expr-bench", "context"]
+runs = 10
+
+[bench.predicate]
+cmd = ["./target/release/examples/expr-bench", "predicate"]
+runs = 10
+
+[bench.regex]
+cmd = ["./target/release/examples/expr-bench", "regex"]
+runs = 10
+
+[bench.json]
+cmd = ["./target/release/examples/expr-bench", "json"]
+runs = 10


### PR DESCRIPTION
## Summary

- pin Tak 0.0.5 through mise
- add fixed startup, context, predicate, regex, and JSON evaluator workloads
- add `mise run perf` and `mise run perf:record`
- record instruction counts on every `main` commit in `refs/notes/tak`

## Why

The performance audit found several costs that normal correctness tests cannot protect. Tak gives the repository deterministic cachegrind instruction counts while keeping the data in git notes.

This intentionally adds post-merge recording only. A PR regression gate needs a baseline series first; after enough `main` measurements exist, a follow-up can add `tak compare` gating without inventing a baseline.

## Stack

- built on #85, which adds the Go expr compatibility corpus
- merge this before #75 and #77

## Checks

- `cargo test --all-features` (111 unit tests, 1 compatibility test, 10 doctests at the top of the stack)
- release build of the `expr-bench` example
- `tak run --no-counters`
- `git diff --check`

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds benchmarking tooling and CI only; no changes to evaluator runtime behavior or production code paths.
> 
> **Overview**
> Adds **deterministic instruction-count benchmarking** with [Tak](https://github.com/jdx/tak) (pinned via mise) so hot-path evaluator cost can be tracked over time in git notes, without gating PRs yet.
> 
> A new `expr-bench` example runs fixed workloads—startup, large-context lookup, `map` predicates, regex `matches`, and `toJSON`—with `black_box` so valgrind/cachegrind counts stay meaningful. `tak.toml` wires five benches (10 runs each); `mise run perf` runs them locally and `mise run perf:record` records results.
> 
> On every push to **main**, a **Perf** workflow installs valgrind, runs `mise run perf:record`, pushes measurements with `tak push`, and appends `tak history` to the job summary. The `[gate]` section in `tak.toml` is configured but regression compare is intentionally deferred until enough baseline data exists on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55601d954291afac7c93a4b8df52299b8a2c4b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->