### PR TITLE
perf(lib)!: borrow compiled programs during evaluation

### DIFF
--- a/examples/expr-bench.rs
+++ b/examples/expr-bench.rs
@@ -17,7 +17,7 @@ fn context() {
     let ctx = Context::from_iter((0..10_000).map(|i| (format!("key_{i}"), i)));
     let program = compile("key_9999 + 1").unwrap();
     for _ in 0..100 {
-        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+        black_box(run(black_box(&program), black_box(&ctx)).unwrap());
     }
 }
 
@@ -26,7 +26,7 @@ fn predicate() {
     let ctx = Context::from_iter([("items", Value::Array(items))]);
     let program = compile("map(items, {# + 1})").unwrap();
     for _ in 0..10 {
-        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+        black_box(run(black_box(&program), black_box(&ctx)).unwrap());
     }
 }
 
@@ -35,7 +35,7 @@ fn regex() {
     let program =
         compile(r#""release-2.0.0" matches "^release-[0-9]+\\.[0-9]+\\.[0-9]+$""#).unwrap();
     for _ in 0..10_000 {
-        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+        black_box(run(black_box(&program), black_box(&ctx)).unwrap());
     }
 }
 
@@ -46,6 +46,6 @@ fn json() {
     let ctx = Context::from_iter([("payload", Value::Map(payload))]);
     let program = compile("toJSON(payload)").unwrap();
     for _ in 0..100 {
-        black_box(run(program.clone(), black_box(&ctx)).unwrap());
+        black_box(run(black_box(&program), black_box(&ctx)).unwrap());
     }
 }

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -85,9 +85,9 @@ impl Environment<'_> {
     pub fn eval_operator(
         &self,
         ctx: &dyn ContextProvider,
-        operator: Operator,
-        left: Node,
-        right: Node,
+        operator: &Operator,
+        left: &Node,
+        right: &Node,
     ) -> Result<Value> {
         let left = self.eval_expr(ctx, left)?;
         match &operator {

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -70,23 +70,23 @@ impl Environment<'_> {
     pub fn eval_postfix_operator(
         &self,
         ctx: &dyn ContextProvider,
-        operator: PostfixOperator,
-        node: Node,
+        operator: &PostfixOperator,
+        node: &Node,
     ) -> Result<Value> {
         let value = self.eval_expr(ctx, node)?;
         let result = match operator {
-            PostfixOperator::Index { idx, optional } => match self.eval_index_key(ctx, *idx)? {
+            PostfixOperator::Index { idx, optional } => match self.eval_index_key(ctx, idx)? {
                 Value::Integer(idx) => match value {
                     Value::Array(arr) => {
                         let idx = i64_to_idx(idx, arr.len());
                         arr.get(idx).cloned().unwrap_or(Value::Nil)
                     }
-                    _ if optional => Value::Nil,
+                    _ if *optional => Value::Nil,
                     _ => bail!("Invalid operand for operator []"),
                 },
                 Value::String(key) => match value {
                     Value::Map(map) => map.get(&key).cloned().unwrap_or(Value::Nil),
-                    _ if optional => Value::Nil,
+                    _ if *optional => Value::Nil,
                     _ => bail!("Invalid operand for operator []"),
                 },
                 v => bail!("Invalid operand for operator []: {v:?}"),
@@ -101,12 +101,12 @@ impl Environment<'_> {
                 _ => bail!("Invalid operand for operator []"),
             },
             PostfixOperator::Default(default) => match value {
-                Value::Nil => self.eval_expr(ctx, *default)?,
+                Value::Nil => self.eval_expr(ctx, default)?,
                 value => value,
             },
             PostfixOperator::Ternary { left, right } => match value {
-                Value::Bool(true) => self.eval_expr(ctx, *left)?,
-                Value::Bool(false) => self.eval_expr(ctx, *right)?,
+                Value::Bool(true) => self.eval_expr(ctx, left)?,
+                Value::Bool(false) => self.eval_expr(ctx, right)?,
                 value => bail!("Invalid condition for ?: {value:?}"),
             },
             PostfixOperator::Pipe(func) => {
@@ -114,14 +114,14 @@ impl Environment<'_> {
                     ident,
                     args,
                     predicate,
-                } = *func
+                } = func.as_ref()
                 {
                     let args = args
-                        .into_iter()
+                        .iter()
                         .map(|arg| self.eval_expr(ctx, arg))
                         .chain(once(Ok(value)))
                         .collect::<Result<Vec<Value>>>()?;
-                    self.eval_func(ctx, ident, args, predicate.map(|p| *p))?
+                    self.eval_func(ctx, ident, args, predicate.as_deref())?
                 } else {
                     bail!("Invalid operand for operator |");
                 }
@@ -131,10 +131,10 @@ impl Environment<'_> {
         Ok(result)
     }
 
-    fn eval_index_key(&self, ctx: &dyn ContextProvider, idx: Node) -> Result<Value> {
+    fn eval_index_key(&self, ctx: &dyn ContextProvider, idx: &Node) -> Result<Value> {
         match idx {
-            Node::Value(v) => Ok(v),
-            Node::Ident(id) => Ok(Value::String(id)),
+            Node::Value(v) => Ok(v.clone()),
+            Node::Ident(id) => Ok(Value::String(id.clone())),
             idx => self.eval_expr(ctx, idx),
         }
     }

--- a/src/ast/unary_operator.rs
+++ b/src/ast/unary_operator.rs
@@ -32,8 +32,8 @@ impl Environment<'_> {
     pub fn eval_unary_operator(
         &self,
         ctx: &dyn ContextProvider,
-        operator: UnaryOperator,
-        node: Node,
+        operator: &UnaryOperator,
+        node: &Node,
     ) -> Result<Value> {
         let node = self.eval_expr(ctx, node)?;
         let result = match operator {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 /// Run a compiled expr program, using the default environment
-pub fn run(program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
+pub fn run(program: &Program, ctx: &dyn ContextProvider) -> Result<Value> {
     DEFAULT_ENVIRONMENT.run(program, ctx)
 }
 
@@ -106,17 +106,17 @@ impl<'a> Environment<'a> {
     }
 
     /// Run a compiled expr program
-    pub fn run(&self, program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
+    pub fn run(&self, program: &Program, ctx: &dyn ContextProvider) -> Result<Value> {
         let mut ctx = ContextScope::new(ctx);
-        for (id, expr) in program.lines {
+        for (id, expr) in &program.lines {
             ctx.insert(id, self.eval_expr(&ctx, expr)?);
         }
-        self.eval_expr(&ctx, program.expr)
+        self.eval_expr(&ctx, &program.expr)
     }
 
     pub(crate) fn run_with_binding(
         &self,
-        program: Program,
+        program: &Program,
         ctx: &dyn ContextProvider,
         key: &str,
         value: Value,
@@ -138,12 +138,12 @@ impl<'a> Environment<'a> {
     /// ```
     pub fn eval(&self, code: &str, ctx: &dyn ContextProvider) -> Result<Value> {
         let program = compile(code)?;
-        self.run(program, ctx)
+        self.run(&program, ctx)
     }
 
-    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: Node) -> Result<Value> {
+    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: &Node) -> Result<Value> {
         let value = match node {
-            Node::Value(value) => value,
+            Node::Value(value) => value.clone(),
             Node::Ident(id) => {
                 if id == "$env" {
                     Value::Map(ctx.environment().0)
@@ -152,7 +152,7 @@ impl<'a> Environment<'a> {
                 } else if let Some(item) = ctx
                     .get("#")
                     .and_then(|o| o.as_map())
-                    .and_then(|m| m.get(&id))
+                    .and_then(|m| m.get(id))
                 {
                     item.clone()
                 } else {
@@ -168,22 +168,22 @@ impl<'a> Environment<'a> {
                     .into_iter()
                     .map(|e| self.eval_expr(ctx, e))
                     .collect::<Result<_>>()?;
-                self.eval_func(ctx, ident, args, predicate.map(|l| *l))?
+                self.eval_func(ctx, ident, args, predicate.as_deref())?
             }
             Node::Operation {
                 left,
                 operator,
                 right,
-            } => self.eval_operator(ctx, operator, *left, *right)?,
-            Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, *node)?,
-            Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, *node)?,
+            } => self.eval_operator(ctx, operator, left, right)?,
+            Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, node)?,
+            Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, node)?,
             Node::Array(a) => Value::Array(
-                a.into_iter()
+                a.iter()
                     .map(|e| self.eval_expr(ctx, e))
                     .collect::<Result<_>>()?,
             ), // node => bail!("unexpected node: {node:?}"),
             Node::Range(start, end) => {
-                match (self.eval_expr(ctx, *start)?, self.eval_expr(ctx, *end)?) {
+                match (self.eval_expr(ctx, start)?, self.eval_expr(ctx, end)?) {
                     (Value::Integer(start), Value::Integer(end)) => {
                         Value::Array((start..=end).map(Value::Integer).collect())
                     }

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -10,7 +10,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(false) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(false.into());
                 }
@@ -29,7 +29,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(true.into());
                 }
@@ -49,7 +49,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     if found {
                         return Ok(false.into());
@@ -71,7 +71,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(false.into());
                 }
@@ -90,7 +90,7 @@ pub fn add_array_functions(env: &mut Environment) {
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
                 result.push(c.env.run_with_binding(
-                    predicate.clone(),
+                    predicate,
                     c.ctx,
                     "#",
                     value.clone(),
@@ -111,7 +111,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     result.push(value.clone());
                 }
@@ -130,7 +130,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(value.clone());
                 }
@@ -149,7 +149,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for (i, value) in a.iter().enumerate() {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(i.into());
                 }
@@ -168,7 +168,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a.iter().rev() {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(value.clone());
                 }
@@ -187,7 +187,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for (i, value) in a.iter().enumerate().rev() {
                 if let Value::Bool(true) =
                     c.env
-                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                        .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     return Ok(i.into());
                 }
@@ -206,7 +206,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in a {
                 if let Some(key) = c
                     .env
-                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                    .run_with_binding(predicate, c.ctx, "#", value.clone())?
                     .as_string()
                 {
                     groups.entry(key.to_string()).or_insert_with(Vec::new).push(value.clone());
@@ -276,7 +276,7 @@ pub fn add_array_functions(env: &mut Environment) {
         for value in a {
             let key = c
                 .env
-                .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?;
+                .run_with_binding(predicate, c.ctx, "#", value.clone())?;
             keyed.push((key, value.clone()));
         }
         keyed.sort_by(|(a, _), (b, _)| {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -14,7 +14,7 @@ pub type Function<'a> = Box<dyn Fn(ExprCall) -> Result<Value> + 'a + Sync + Send
 pub struct ExprCall<'a, 'b> {
     pub ident: String,
     pub args: Vec<Value>,
-    pub predicate: Option<Program>,
+    pub predicate: Option<&'a Program>,
     pub ctx: &'a dyn ContextProvider,
     pub env: &'a Environment<'b>,
 }
@@ -23,12 +23,12 @@ impl Environment<'_> {
     pub fn eval_func(
         &self,
         ctx: &dyn ContextProvider,
-        ident: String,
+        ident: &str,
         args: Vec<Value>,
-        predicate: Option<Program>,
+        predicate: Option<&Program>,
     ) -> Result<Value> {
         let call = ExprCall {
-            ident,
+            ident: ident.to_string(),
             args,
             predicate,
             ctx,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,7 +83,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Run a compiled expr program
-    pub fn run(&self, program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
+    pub fn run(&self, program: &Program, ctx: &dyn ContextProvider) -> Result<Value> {
         self.env.run(program, ctx)
     }
 
@@ -101,7 +101,7 @@ impl<'a> Parser<'a> {
         self.env.eval(code, ctx)
     }
 
-    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: Node) -> Result<Value> {
+    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: &Node) -> Result<Value> {
         self.env.eval_expr(ctx, node)
     }
 }


### PR DESCRIPTION
## Summary

- change `run`, `Environment::run`, and deprecated `Parser::run` to borrow `&Program`
- evaluate borrowed AST nodes and operators instead of consuming them
- pass predicate programs by reference through `ExprCall`
- stop cloning predicate ASTs for every array element

## Why

A compiled program should be reusable. The old API consumed the AST, forcing callers to clone it for repeated evaluation, and predicate built-ins cloned their nested program for every item. This is a breaking API change intended for v2.

Value results are still owned; this PR only removes structural AST clones and leaves evaluation semantics unchanged.

## Stack

- built on #74
- merge #74 first, then this PR before #77

## Checks

- `cargo test --all-features` (111 unit tests, 1 compatibility test, 10 doctests at the top of the stack)
- release Tak workload run
- `git diff --check`

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide breaking API surface across the evaluator and `ExprCall`, but behavior is intended to stay the same; main risk is missed call-site updates and subtle lifetime/borrow issues in custom function code.
> 
> **Overview**
> **Breaking change:** `run`, `Environment::run`, and deprecated `Parser::run` now take `&Program` instead of owning the program, so a compiled program can be evaluated many times without cloning the AST.
> 
> Evaluation walks the AST by reference: `eval_expr` and operator/postfix/unary evaluators take `&Node` / `&Operator` (with clones only where a `Value` or string is produced). `ExprCall::predicate` is `Option<&Program>`, and array builtins (`map`, `filter`, `all`, etc.) pass that reference into `run_with_binding` instead of cloning the predicate program per element.
> 
> The `expr-bench` example is updated to pass `&program` and drop per-iteration `program.clone()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b6c6ae3f4b9e88bb83904fe88c916865237ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->