### PR TITLE
perf(lib): borrow evaluation contexts

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,7 +1,7 @@
 use crate::ast::node::Node;
 use crate::Value::{Array, Bool, Float, Integer, Map, String};
 use crate::{bail, Result, Rule};
-use crate::{Context, Environment, Value};
+use crate::{Environment, EvalContext, Value};
 use log::trace;
 use pest::iterators::Pair;
 use std::str::FromStr;
@@ -61,17 +61,17 @@ impl From<Pair<'_, Rule>> for Operator {
 impl Environment<'_> {
     pub fn eval_operator(
         &self,
-        ctx: &Context,
+        ctx: &EvalContext,
         operator: &Operator,
         left: &Node,
         right: &Node,
     ) -> Result<Value> {
-        let left = self.eval_expr(ctx, left)?;
+        let left = self.eval_node(ctx, left)?;
         match &operator {
             Operator::And => {
                 return match left {
                     Bool(false) => Ok(Bool(false)),
-                    Bool(true) => match self.eval_expr(ctx, right)? {
+                    Bool(true) => match self.eval_node(ctx, right)? {
                         Bool(value) => Ok(Bool(value)),
                         _ => bail!("Invalid operands for operator {operator}"),
                     },
@@ -81,7 +81,7 @@ impl Environment<'_> {
             Operator::Or => {
                 return match left {
                     Bool(true) => Ok(Bool(true)),
-                    Bool(false) => match self.eval_expr(ctx, right)? {
+                    Bool(false) => match self.eval_node(ctx, right)? {
                         Bool(value) => Ok(Bool(value)),
                         _ => bail!("Invalid operands for operator {operator}"),
                     },
@@ -90,7 +90,7 @@ impl Environment<'_> {
             }
             _ => {}
         }
-        let right = self.eval_expr(ctx, right)?;
+        let right = self.eval_node(ctx, right)?;
         let result = match operator {
             Operator::Add => match (left, right) {
                 (Integer(left), Integer(right)) => (left + right).into(),

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 use crate::ast::node::Node;
 use crate::Rule;
 use crate::{bail, Result};
-use crate::{Context, Environment, Value};
+use crate::{Environment, EvalContext, Value};
 use log::trace;
 use pest::iterators::Pair;
 
@@ -69,11 +69,11 @@ impl From<Pair<'_, Rule>> for PostfixOperator {
 impl Environment<'_> {
     pub fn eval_postfix_operator(
         &self,
-        ctx: &Context,
+        ctx: &EvalContext,
         operator: &PostfixOperator,
         node: &Node,
     ) -> Result<Value> {
-        let value = self.eval_expr(ctx, node)?;
+        let value = self.eval_node(ctx, node)?;
         let result = match operator {
             PostfixOperator::Index { idx, optional } => match self.eval_index_key(ctx, idx)? {
                 Value::Integer(idx) => match value {
@@ -101,12 +101,12 @@ impl Environment<'_> {
                 _ => bail!("Invalid operand for operator []"),
             },
             PostfixOperator::Default(default) => match value {
-                Value::Nil => self.eval_expr(ctx, default)?,
+                Value::Nil => self.eval_node(ctx, default)?,
                 value => value,
             },
             PostfixOperator::Ternary { left, right } => match value {
-                Value::Bool(true) => self.eval_expr(ctx, left)?,
-                Value::Bool(false) => self.eval_expr(ctx, right)?,
+                Value::Bool(true) => self.eval_node(ctx, left)?,
+                Value::Bool(false) => self.eval_node(ctx, right)?,
                 value => bail!("Invalid condition for ?: {value:?}"),
             },
             PostfixOperator::Pipe(func) => {
@@ -117,7 +117,7 @@ impl Environment<'_> {
                 } = func.as_ref()
                 {
                     let args = args.iter()
-                        .map(|arg| self.eval_expr(ctx, arg))
+                        .map(|arg| self.eval_node(ctx, arg))
                         .chain(once(Ok(value)))
                         .collect::<Result<Vec<Value>>>()?;
                     self.eval_func(ctx, ident, args, predicate.as_deref())?
@@ -130,11 +130,11 @@ impl Environment<'_> {
         Ok(result)
     }
 
-    fn eval_index_key(&self, ctx: &Context, idx: &Node) -> Result<Value> {
+    fn eval_index_key(&self, ctx: &EvalContext, idx: &Node) -> Result<Value> {
         match idx {
             Node::Value(v) => Ok(v.clone()),
             Node::Ident(id) => Ok(Value::String(id.clone())),
-            idx => self.eval_expr(ctx, idx),
+            idx => self.eval_node(ctx, idx),
         }
     }
 }

--- a/src/ast/unary_operator.rs
+++ b/src/ast/unary_operator.rs
@@ -2,7 +2,7 @@ use crate::ast::node::Node;
 use crate::Rule;
 use crate::Value::Bool;
 use crate::{bail, Result};
-use crate::{Context, Environment, Value};
+use crate::{Environment, EvalContext, Value};
 use log::trace;
 use pest::iterators::Pair;
 use std::str::FromStr;
@@ -31,11 +31,11 @@ impl From<Pair<'_, Rule>> for UnaryOperator {
 impl Environment<'_> {
     pub fn eval_unary_operator(
         &self,
-        ctx: &Context,
+        ctx: &EvalContext,
         operator: &UnaryOperator,
         node: &Node,
     ) -> Result<Value> {
-        let node = self.eval_expr(ctx, node)?;
+        let node = self.eval_node(ctx, node)?;
         let result = match operator {
             UnaryOperator::Not => match node {
                 Bool(b) => Bool(!b),

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,6 +19,100 @@ impl Context {
     }
 }
 
+pub(crate) trait ContextLookup {
+    fn lookup(&self, key: &str) -> Option<&Value>;
+    fn extend_map(&self, map: &mut IndexMap<String, Value>);
+}
+
+impl ContextLookup for Context {
+    fn lookup(&self, key: &str) -> Option<&Value> {
+        self.get(key)
+    }
+
+    fn extend_map(&self, map: &mut IndexMap<String, Value>) {
+        map.extend(self.0.iter().map(|(key, value)| (key.clone(), value.clone())));
+    }
+}
+
+/// A read-only view of the variables visible during evaluation.
+///
+/// Function callbacks receive this type as their `ctx` field. Use
+/// [`EvalContext::get`] for lookups, or [`EvalContext::to_context`] when an owned
+/// context is required.
+pub struct EvalContext<'a> {
+    parent: &'a dyn ContextLookup,
+    binding: Option<(&'a str, &'a Value)>,
+    locals: IndexMap<String, Value>,
+}
+
+impl<'a> EvalContext<'a> {
+    pub(crate) fn new(parent: &'a dyn ContextLookup) -> Self {
+        Self {
+            parent,
+            binding: None,
+            locals: IndexMap::new(),
+        }
+    }
+
+    pub(crate) fn with_binding(
+        parent: &'a dyn ContextLookup,
+        key: &'a str,
+        value: &'a Value,
+    ) -> Self {
+        Self {
+            parent,
+            binding: Some((key, value)),
+            locals: IndexMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.lookup(key)
+    }
+
+    pub fn to_context(&self) -> Context {
+        let mut map = IndexMap::new();
+        self.extend_map(&mut map);
+        Context(map)
+    }
+
+    pub(crate) fn environment_context(&self) -> Context {
+        let mut map = IndexMap::new();
+        self.parent.extend_map(&mut map);
+        if let Some((key, value)) = self.binding {
+            map.insert(key.to_string(), value.clone());
+        }
+        Context(map)
+    }
+
+    pub(crate) fn insert(&mut self, key: String, value: Value) {
+        self.locals.insert(key, value);
+    }
+}
+
+impl ContextLookup for EvalContext<'_> {
+    fn lookup(&self, key: &str) -> Option<&Value> {
+        self.locals.get(key).or_else(|| {
+            self.binding
+                .filter(|(binding, _)| *binding == key)
+                .map(|(_, value)| value)
+                .or_else(|| self.parent.lookup(key))
+        })
+    }
+
+    fn extend_map(&self, map: &mut IndexMap<String, Value>) {
+        self.parent.extend_map(map);
+        if let Some((key, value)) = self.binding {
+            map.insert(key.to_string(), value.clone());
+        }
+        map.extend(
+            self.locals
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+}
+
 impl<S: Display, T: Into<Value>> FromIterator<(S, T)> for Context {
     fn from_iter<I: IntoIterator<Item=(S, T)>>(iter: I) -> Self {
         let mut ctx = Self::default();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2,7 +2,7 @@ use crate::ast::node::Node;
 use crate::ast::program::Program;
 use crate::functions::{ExprCall, Function, array, bitwise, convert, json, string};
 use crate::parser::compile;
-use crate::{Context, Result, Value, bail};
+use crate::{Context, EvalContext, Result, Value, bail};
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use std::fmt;
@@ -101,12 +101,26 @@ impl<'a> Environment<'a> {
 
     /// Run a compiled expr program
     pub fn run(&self, program: &Program, ctx: &Context) -> Result<Value> {
-        let mut ctx = ctx.clone();
-        ctx.insert("$env".to_string(), Value::Map(ctx.0.clone()));
+        let mut ctx = EvalContext::new(ctx);
+        self.run_in_context(program, &mut ctx)
+    }
+
+    fn run_in_context(&self, program: &Program, ctx: &mut EvalContext) -> Result<Value> {
         for (id, expr) in &program.lines {
-            ctx.insert(id, self.eval_expr(&ctx, expr)?);
+            ctx.insert(id.clone(), self.eval_node(ctx, expr)?);
         }
-        self.eval_expr(&ctx, &program.expr)
+        self.eval_node(ctx, &program.expr)
+    }
+
+    pub(crate) fn run_with_binding(
+        &self,
+        program: &Program,
+        parent: &EvalContext,
+        key: &str,
+        value: &Value,
+    ) -> Result<Value> {
+        let mut ctx = EvalContext::with_binding(parent, key, value);
+        self.run_in_context(program, &mut ctx)
     }
 
     /// Compile and run an expr program in one step
@@ -125,10 +139,17 @@ impl<'a> Environment<'a> {
     }
 
     pub fn eval_expr(&self, ctx: &Context, node: &Node) -> Result<Value> {
+        let ctx = EvalContext::new(ctx);
+        self.eval_node(&ctx, node)
+    }
+
+    pub(crate) fn eval_node(&self, ctx: &EvalContext, node: &Node) -> Result<Value> {
         let value = match node {
             Node::Value(value) => value.clone(),
             Node::Ident(id) => {
-                if let Some(value) = ctx.get(&id) {
+                if id == "$env" {
+                    Value::Map(ctx.environment_context().0)
+                } else if let Some(value) = ctx.get(id) {
                     value.clone()
                 } else if let Some(item) = ctx
                     .get("#")
@@ -146,8 +167,8 @@ impl<'a> Environment<'a> {
                 predicate,
             } => {
                 let args = args
-                    .into_iter()
-                    .map(|e| self.eval_expr(ctx, e))
+                    .iter()
+                    .map(|e| self.eval_node(ctx, e))
                     .collect::<Result<_>>()?;
                 self.eval_func(ctx, ident, args, predicate.as_deref())?
             },
@@ -160,10 +181,10 @@ impl<'a> Environment<'a> {
             Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, node)?,
             Node::Array(a) => Value::Array(
                 a.iter()
-                    .map(|e| self.eval_expr(ctx, e))
+                    .map(|e| self.eval_node(ctx, e))
                     .collect::<Result<_>>()?,
             ), // node => bail!("unexpected node: {node:?}"),
-            Node::Range(start, end) => match (self.eval_expr(ctx, start)?, self.eval_expr(ctx, end)?) {
+            Node::Range(start, end) => match (self.eval_node(ctx, start)?, self.eval_node(ctx, end)?) {
                 (Value::Integer(start), Value::Integer(end)) => {
                     Value::Array((start..=end).map(Value::Integer).collect())
                 }

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -8,9 +8,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(false) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(false) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(false.into());
                 }
             }
@@ -26,9 +24,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(true.into());
                 }
             }
@@ -45,9 +41,7 @@ pub fn add_array_functions(env: &mut Environment) {
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             let mut found = false;
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     if found {
                         return Ok(false.into());
                     }
@@ -66,9 +60,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(false.into());
                 }
             }
@@ -85,9 +77,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                result.push(c.env.run(predicate, &ctx)?);
+                result.push(c.env.run_with_binding(predicate, c.ctx, "#", value)?);
             }
         } else {
             bail!("map() takes an array as the first argument");
@@ -102,9 +92,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     result.push(value.clone());
                 }
             }
@@ -120,9 +108,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(value.clone());
                 }
             }
@@ -138,9 +124,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for (i, value) in a.iter().enumerate() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(i.into());
                 }
             }
@@ -156,9 +140,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a.iter().rev() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(value.clone());
                 }
             }
@@ -174,9 +156,7 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for (i, value) in a.iter().enumerate().rev() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate, &ctx)? {
+                if let Value::Bool(true) = c.env.run_with_binding(predicate, c.ctx, "#", value)? {
                     return Ok(i.into());
                 }
             }
@@ -192,9 +172,11 @@ pub fn add_array_functions(env: &mut Environment) {
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             let mut groups = IndexMap::new();
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Some(key) = c.env.run(predicate, &ctx)?.as_string() {
+                if let Some(key) = c
+                    .env
+                    .run_with_binding(predicate, c.ctx, "#", value)?
+                    .as_string()
+                {
                     groups.entry(key.to_string()).or_insert_with(Vec::new).push(value.clone());
                 } else {
                     bail!("groupBy() predicate must return a string");
@@ -256,9 +238,7 @@ pub fn add_array_functions(env: &mut Environment) {
         // Compute keys for each element
         let mut keyed: Vec<(Value, Value)> = Vec::new();
         for value in a {
-            let mut ctx = c.ctx.clone();
-            ctx.insert("#".to_string(), value.clone());
-            let key = c.env.run(predicate, &ctx)?;
+            let key = c.env.run_with_binding(predicate, c.ctx, "#", value)?;
             keyed.push((key, value.clone()));
         }
         keyed.sort_by(|(a, _), (b, _)| {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -7,20 +7,20 @@ pub mod string;
 use crate::Result;
 
 use crate::ast::program::Program;
-use crate::{bail, Context, Environment, Value};
+use crate::{bail, Environment, EvalContext, Value};
 
 pub type Function<'a> = Box<dyn Fn(ExprCall) -> Result<Value> + 'a + Sync + Send>;
 
-pub struct ExprCall<'a, 'b> {
+pub struct ExprCall<'a, 'b, 'c> {
     pub ident: String,
     pub args: Vec<Value>,
     pub predicate: Option<&'a Program>,
-    pub ctx: &'a Context,
-    pub env: &'a Environment<'b>,
+    pub ctx: &'a EvalContext<'b>,
+    pub env: &'a Environment<'c>,
 }
 
 impl Environment<'_> {
-    pub fn eval_func(&self, ctx: &Context, ident: &str, args: Vec<Value>, predicate: Option<&Program>) -> Result<Value> {
+    pub fn eval_func(&self, ctx: &EvalContext, ident: &str, args: Vec<Value>, predicate: Option<&Program>) -> Result<Value> {
         let call = ExprCall {
             ident: ident.to_string(),
             args,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod serde;
 mod test;
 mod value;
 
-pub use crate::context::Context;
+pub use crate::context::{Context, EvalContext};
 pub use crate::error::{Error, Result};
 pub use crate::eval::{Environment, run, eval};
 pub use crate::parser::compile;

--- a/src/test.rs
+++ b/src/test.rs
@@ -200,6 +200,7 @@ fn context() -> Result<()> {
         eval(r#"$env["Version"]"#, &ctx)?.to_string(),
         r#""v1.0.0""#
     );
+    assert_eq!(eval(r#"let x = 1; "x" in $env"#, &ctx)?.to_string(), "false");
     Ok(())
 }
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core variable-resolution and $env semantics path; behavior change is intentional and covered by tests, but regressions in scoping or custom functions are possible.
> 
> **Overview**
> Replaces per-step **`Context` cloning** during evaluation with a borrowed **`EvalContext`** that layers a parent lookup, optional single bindings (e.g. `#` in predicates), and **`let`** locals.
> 
> **`Environment::run`** now walks programs via **`run_in_context`** / **`eval_node`**, storing line results in **`EvalContext::insert`** instead of mutating a cloned map. Array helpers (**`map`**, **`filter`**, **`all`**, etc.) call **`run_with_binding`** rather than cloning context and inserting `#` each iteration. **`ExprCall`** and built-in eval paths take **`&EvalContext`**; **`EvalContext`** is re-exported for custom functions.
> 
> **`$env`** is built from the outer environment plus the current binding only—**not** script **`let`** bindings—verified by a new test that **`"x" in $env"`** is false after **`let x = 1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2887962f773c42a33e238037b5f35c78800317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->