### PR TITLE
perf(parse): precompile literal regexes

### DIFF
--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -23,6 +23,7 @@ pub enum Node {
         operator: Operator,
         left: Box<Node>,
         right: Box<Node>,
+        compiled_regex: Option<regex::Regex>,
     },
     Postfix {
         operator: PostfixOperator,
@@ -83,10 +84,20 @@ impl From<Pairs<'_, Rule>> for Node {
                 operator: operator.into(),
                 node: Box::new(left),
             })
-            .map_infix(|left, operator, right| Node::Operation {
-                operator: operator.into(),
-                left: Box::new(left),
-                right: Box::new(right),
+            .map_infix(|left, operator, right| {
+                let operator = operator.into();
+                let compiled_regex = match (&operator, &right) {
+                    (Operator::Matches, Node::Value(Value::String(pattern))) => {
+                        regex::Regex::new(pattern).ok()
+                    }
+                    _ => None,
+                };
+                Node::Operation {
+                    operator,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    compiled_regex,
+                }
             })
             .parse(pairs)
     }

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -88,6 +88,7 @@ impl Environment<'_> {
         operator: &Operator,
         left: &Node,
         right: &Node,
+        compiled_regex: Option<&regex::Regex>,
     ) -> Result<Value> {
         let left = self.eval_expr(ctx, left)?;
         match &operator {
@@ -217,8 +218,11 @@ impl Environment<'_> {
             },
             Operator::Matches => match (left, right) {
                 (String(left), String(right)) => {
-                    let re = regex::Regex::new(&right)?;
-                    Bool(re.is_match(&left))
+                    if let Some(regex) = compiled_regex {
+                        Bool(regex.is_match(&left))
+                    } else {
+                        Bool(regex::Regex::new(&right)?.is_match(&left))
+                    }
                 }
                 _ => bail!("Invalid operands for operator matches"),
             },

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -174,7 +174,8 @@ impl<'a> Environment<'a> {
                 left,
                 operator,
                 right,
-            } => self.eval_operator(ctx, operator, left, right)?,
+                compiled_regex,
+            } => self.eval_operator(ctx, operator, left, right, compiled_regex.as_ref())?,
             Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, node)?,
             Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, node)?,
             Node::Array(a) => Value::Array(

--- a/src/test.rs
+++ b/src/test.rs
@@ -179,6 +179,13 @@ bar`"#,
     Ok(())
 }
 
+#[test]
+fn dynamic_matches() -> Result<()> {
+    let ctx = Context::from_iter([("pattern", "^f")]);
+    assert_eq!(eval(r#""foo" matches pattern"#, &ctx)?.to_string(), "true");
+    Ok(())
+}
+
 test!(nil, "nil", "nil");
 test!(comment_line, "1 // foo", "1");
 test!(comment_block, r#"/*


### PR DESCRIPTION
## Summary

- compile literal `matches` patterns while constructing the AST
- reuse the compiled regex on every evaluation of the program
- retain runtime compilation for dynamic pattern expressions
- preserve evaluation-time errors for invalid literal patterns

## Performance

For 10,000 evaluations of the same literal pattern, the Tak workload improved from a 110.97 ms wall-clock mean to 1.81 ms locally, about 61x faster. Tak's instruction-count history will provide the deterministic long-term measurement after #74 lands.

## Stack

- built on #75
- merge #74 and #75 first

## Checks

- `cargo test --all-features` (111 unit tests, 1 compatibility test, 10 doctests)
- dynamic-pattern coverage
- release Tak regex workload before and after this commit
- `git diff --check`

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted performance optimization on the matches operator with a clear fallback for dynamic patterns; behavior is covered by existing and new tests.
> 
> **Overview**
> **Literal `matches` patterns are compiled once at parse time** and stored on `Node::Operation` as an optional `compiled_regex`, so repeated evaluation of the same expression no longer re-parses the pattern on every run.
> 
> Parsing only precompiles when the right operand is a **string literal**; invalid literals are left unset so **`Regex::new` still runs at evaluation** and preserves existing error behavior. **Variable or other dynamic patterns** still compile on each evaluation via the fallback path in `eval_operator`.
> 
> A **`dynamic_matches`** test confirms `"foo" matches pattern` with a context variable still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ac69cefce0a9cd0942c5e3e879794e883bd219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->