### PR TITLE
feat(lib)!: add borrowed and serializable contexts

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,7 +1,7 @@
 use crate::ast::node::Node;
 use crate::Value::{Array, Bool, Float, Integer, Map, String};
 use crate::{bail, Result, Rule};
-use crate::{Context, Environment, Value};
+use crate::{ContextProvider, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
 use std::str::FromStr;
@@ -84,7 +84,7 @@ fn values_equal(left: &Value, right: &Value) -> bool {
 impl Environment<'_> {
     pub fn eval_operator(
         &self,
-        ctx: &Context,
+        ctx: &dyn ContextProvider,
         operator: Operator,
         left: Node,
         right: Node,

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -1,10 +1,10 @@
-use std::iter::once;
 use crate::ast::node::Node;
 use crate::Rule;
 use crate::{bail, Result};
-use crate::{Context, Environment, Value};
+use crate::{ContextProvider, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
+use std::iter::once;
 
 #[derive(Debug, Clone, strum::Display)]
 pub enum PostfixOperator {
@@ -69,7 +69,7 @@ impl From<Pair<'_, Rule>> for PostfixOperator {
 impl Environment<'_> {
     pub fn eval_postfix_operator(
         &self,
-        ctx: &Context,
+        ctx: &dyn ContextProvider,
         operator: PostfixOperator,
         node: Node,
     ) -> Result<Value> {
@@ -116,7 +116,8 @@ impl Environment<'_> {
                     predicate,
                 } = *func
                 {
-                    let args = args.into_iter()
+                    let args = args
+                        .into_iter()
                         .map(|arg| self.eval_expr(ctx, arg))
                         .chain(once(Ok(value)))
                         .collect::<Result<Vec<Value>>>()?;
@@ -130,7 +131,7 @@ impl Environment<'_> {
         Ok(result)
     }
 
-    fn eval_index_key(&self, ctx: &Context, idx: Node) -> Result<Value> {
+    fn eval_index_key(&self, ctx: &dyn ContextProvider, idx: Node) -> Result<Value> {
         match idx {
             Node::Value(v) => Ok(v),
             Node::Ident(id) => Ok(Value::String(id)),

--- a/src/ast/unary_operator.rs
+++ b/src/ast/unary_operator.rs
@@ -2,7 +2,7 @@ use crate::ast::node::Node;
 use crate::Rule;
 use crate::Value::Bool;
 use crate::{bail, Result};
-use crate::{Context, Environment, Value};
+use crate::{ContextProvider, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
 use std::str::FromStr;
@@ -31,7 +31,7 @@ impl From<Pair<'_, Rule>> for UnaryOperator {
 impl Environment<'_> {
     pub fn eval_unary_operator(
         &self,
-        ctx: &Context,
+        ctx: &dyn ContextProvider,
         operator: UnaryOperator,
         node: Node,
     ) -> Result<Value> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{bail, Result, Value};
 use indexmap::IndexMap;
 use std::fmt::Display;
 
@@ -17,14 +17,128 @@ impl Context {
     pub fn get(&self, key: &str) -> Option<&Value> {
         self.0.get(key)
     }
+
+    /// Build a context from any serializable map or struct.
+    #[cfg(feature = "serde")]
+    pub fn from_serialize<T: serde::Serialize + ?Sized>(value: &T) -> Result<Self> {
+        crate::to_value(value)?.try_into()
+    }
+}
+
+/// A borrowed source of values used while evaluating an expression.
+///
+/// Implementing this trait allows callers and custom functions to provide
+/// context values without cloning an entire [`Context`] for each evaluation.
+pub trait ContextProvider {
+    fn get(&self, key: &str) -> Option<&Value>;
+
+    /// Materialize the values visible to the expression.
+    ///
+    /// Evaluation only calls this when an expression accesses `$env`.
+    fn to_context(&self) -> Context;
+
+    #[doc(hidden)]
+    fn environment(&self) -> Context {
+        self.to_context()
+    }
+}
+
+impl ContextProvider for Context {
+    fn get(&self, key: &str) -> Option<&Value> {
+        self.get(key)
+    }
+
+    fn to_context(&self) -> Context {
+        self.clone()
+    }
+}
+
+pub(crate) struct ContextScope<'a> {
+    parent: &'a dyn ContextProvider,
+    values: Context,
+}
+
+impl<'a> ContextScope<'a> {
+    pub(crate) fn new(parent: &'a dyn ContextProvider) -> Self {
+        Self {
+            parent,
+            values: Context::default(),
+        }
+    }
+
+    pub(crate) fn insert<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<String>,
+        V: Into<Value>,
+    {
+        self.values.insert(key, value);
+    }
+}
+
+impl ContextProvider for ContextScope<'_> {
+    fn get(&self, key: &str) -> Option<&Value> {
+        self.values.get(key).or_else(|| self.parent.get(key))
+    }
+
+    fn to_context(&self) -> Context {
+        let mut context = self.parent.to_context();
+        for (key, value) in &self.values.0 {
+            context.insert(key.clone(), value.clone());
+        }
+        context
+    }
+
+    fn environment(&self) -> Context {
+        self.parent.environment()
+    }
+}
+
+impl TryFrom<Value> for Context {
+    type Error = crate::Error;
+
+    fn try_from(value: Value) -> Result<Self> {
+        match value {
+            Value::Map(values) => Ok(Self(values)),
+            value => bail!("context must be a map, got {value:?}"),
+        }
+    }
 }
 
 impl<S: Display, T: Into<Value>> FromIterator<(S, T)> for Context {
-    fn from_iter<I: IntoIterator<Item=(S, T)>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = (S, T)>>(iter: I) -> Self {
         let mut ctx = Self::default();
         for (k, v) in iter {
             ctx.insert(k.to_string(), v);
         }
         ctx
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::Context;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Settings<'a> {
+        name: &'a str,
+        retries: u8,
+    }
+
+    #[test]
+    fn context_from_serializable_struct() {
+        let context = Context::from_serialize(&Settings {
+            name: "mise",
+            retries: 3,
+        })
+        .unwrap();
+
+        assert_eq!(context.get("name").unwrap().as_string(), Some("mise"));
+        assert_eq!(context.get("retries").unwrap().as_integer(), Some(3));
+    }
+
+    #[test]
+    fn context_rejects_non_map_values() {
+        assert!(Context::from_serialize(&[1, 2, 3]).is_err());
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,15 +1,16 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
-use crate::functions::{ExprCall, Function, array, bitwise, convert, json, string};
+use crate::context::ContextScope;
+use crate::functions::{array, bitwise, convert, json, string, ExprCall, Function};
 use crate::parser::compile;
-use crate::{Context, Result, Value, bail};
+use crate::{bail, ContextProvider, Result, Value};
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 /// Run a compiled expr program, using the default environment
-pub fn run(program: Program, ctx: &Context) -> Result<Value> {
+pub fn run(program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
     DEFAULT_ENVIRONMENT.run(program, ctx)
 }
 
@@ -21,7 +22,7 @@ pub fn run(program: Program, ctx: &Context) -> Result<Value> {
 /// let ctx = Context::default();
 /// assert_eq!(eval("1 + 2", &ctx).unwrap().to_string(), "3");
 /// ```
-pub fn eval(code: &str, ctx: &Context) -> Result<Value> {
+pub fn eval(code: &str, ctx: &dyn ContextProvider) -> Result<Value> {
     DEFAULT_ENVIRONMENT.eval(code, ctx)
 }
 
@@ -47,7 +48,6 @@ pub fn eval(code: &str, ctx: &Context) -> Result<Value> {
 /// });
 /// assert_eq!(env.eval("add(1, 2, 3)", &ctx).unwrap().to_string(), "6");
 /// ```
-#[derive(Default)]
 pub struct Environment<'a> {
     pub(crate) functions: IndexMap<String, Function<'a>>,
 }
@@ -55,6 +55,12 @@ pub struct Environment<'a> {
 impl Debug for Environment<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("ExprEnvironment").finish()
+    }
+}
+
+impl Default for Environment<'_> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -100,13 +106,24 @@ impl<'a> Environment<'a> {
     }
 
     /// Run a compiled expr program
-    pub fn run(&self, program: Program, ctx: &Context) -> Result<Value> {
-        let mut ctx = ctx.clone();
-        ctx.insert("$env".to_string(), Value::Map(ctx.0.clone()));
+    pub fn run(&self, program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
+        let mut ctx = ContextScope::new(ctx);
         for (id, expr) in program.lines {
             ctx.insert(id, self.eval_expr(&ctx, expr)?);
         }
         self.eval_expr(&ctx, program.expr)
+    }
+
+    pub(crate) fn run_with_binding(
+        &self,
+        program: Program,
+        ctx: &dyn ContextProvider,
+        key: &str,
+        value: Value,
+    ) -> Result<Value> {
+        let mut scope = ContextScope::new(ctx);
+        scope.insert(key, value);
+        self.run(program, &scope)
     }
 
     /// Compile and run an expr program in one step
@@ -119,16 +136,18 @@ impl<'a> Environment<'a> {
     /// let ctx = Context::default();
     /// assert_eq!(env.eval("1 + 2", &ctx).unwrap().to_string(), "3");
     /// ```
-    pub fn eval(&self, code: &str, ctx: &Context) -> Result<Value> {
+    pub fn eval(&self, code: &str, ctx: &dyn ContextProvider) -> Result<Value> {
         let program = compile(code)?;
         self.run(program, ctx)
     }
 
-    pub fn eval_expr(&self, ctx: &Context, node: Node) -> Result<Value> {
+    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: Node) -> Result<Value> {
         let value = match node {
             Node::Value(value) => value,
             Node::Ident(id) => {
-                if let Some(value) = ctx.get(&id) {
+                if id == "$env" {
+                    Value::Map(ctx.environment().0)
+                } else if let Some(value) = ctx.get(&id) {
                     value.clone()
                 } else if let Some(item) = ctx
                     .get("#")
@@ -150,7 +169,7 @@ impl<'a> Environment<'a> {
                     .map(|e| self.eval_expr(ctx, e))
                     .collect::<Result<_>>()?;
                 self.eval_func(ctx, ident, args, predicate.map(|l| *l))?
-            },
+            }
             Node::Operation {
                 left,
                 operator,
@@ -163,17 +182,17 @@ impl<'a> Environment<'a> {
                     .map(|e| self.eval_expr(ctx, e))
                     .collect::<Result<_>>()?,
             ), // node => bail!("unexpected node: {node:?}"),
-            Node::Range(start, end) => match (self.eval_expr(ctx, *start)?, self.eval_expr(ctx, *end)?) {
-                (Value::Integer(start), Value::Integer(end)) => {
-                    Value::Array((start..=end).map(Value::Integer).collect())
+            Node::Range(start, end) => {
+                match (self.eval_expr(ctx, *start)?, self.eval_expr(ctx, *end)?) {
+                    (Value::Integer(start), Value::Integer(end)) => {
+                        Value::Array((start..=end).map(Value::Integer).collect())
+                    }
+                    (start, end) => bail!("invalid range: {start:?}..{end:?}"),
                 }
-                (start, end) => bail!("invalid range: {start:?}..{end:?}"),
             }
         };
         Ok(value)
     }
 }
 
-pub(crate) static DEFAULT_ENVIRONMENT: Lazy<Environment> = Lazy::new(|| {
-    Environment::new()
-});
+pub(crate) static DEFAULT_ENVIRONMENT: Lazy<Environment> = Lazy::new(Environment::new);

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -1,5 +1,5 @@
-use indexmap::IndexMap;
 use crate::{bail, Environment, Value};
+use indexmap::IndexMap;
 
 pub fn add_array_functions(env: &mut Environment) {
     env.add_function("all", |c| {
@@ -8,9 +8,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(false) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(false) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(false.into());
                 }
             }
@@ -26,9 +27,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(true.into());
                 }
             }
@@ -45,9 +47,10 @@ pub fn add_array_functions(env: &mut Environment) {
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             let mut found = false;
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     if found {
                         return Ok(false.into());
                     }
@@ -66,9 +69,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(false.into());
                 }
             }
@@ -85,9 +89,12 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                result.push(c.env.run(predicate.clone(), &ctx)?);
+                result.push(c.env.run_with_binding(
+                    predicate.clone(),
+                    c.ctx,
+                    "#",
+                    value.clone(),
+                )?);
             }
         } else {
             bail!("map() takes an array as the first argument");
@@ -102,9 +109,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     result.push(value.clone());
                 }
             }
@@ -120,9 +128,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(value.clone());
                 }
             }
@@ -138,9 +147,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for (i, value) in a.iter().enumerate() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(i.into());
                 }
             }
@@ -156,9 +166,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for value in a.iter().rev() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(value.clone());
                 }
             }
@@ -174,9 +185,10 @@ pub fn add_array_functions(env: &mut Environment) {
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             for (i, value) in a.iter().enumerate().rev() {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Value::Bool(true) = c.env.run(predicate.clone(), &ctx)? {
+                if let Value::Bool(true) =
+                    c.env
+                        .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
                     return Ok(i.into());
                 }
             }
@@ -192,9 +204,11 @@ pub fn add_array_functions(env: &mut Environment) {
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
             let mut groups = IndexMap::new();
             for value in a {
-                let mut ctx = c.ctx.clone();
-                ctx.insert("#".to_string(), value.clone());
-                if let Some(key) = c.env.run(predicate.clone(), &ctx)?.as_string() {
+                if let Some(key) = c
+                    .env
+                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                    .as_string()
+                {
                     groups.entry(key.to_string()).or_insert_with(Vec::new).push(value.clone());
                 } else {
                     bail!("groupBy() predicate must return a string");
@@ -229,7 +243,11 @@ pub fn add_array_functions(env: &mut Environment) {
                 (Value::String(a), Value::String(b)) => a.cmp(b),
                 (a, b) => a.to_string().cmp(&b.to_string()),
             };
-            if desc { cmp.reverse() } else { cmp }
+            if desc {
+                cmp.reverse()
+            } else {
+                cmp
+            }
         });
         Ok(result.into())
     });
@@ -256,9 +274,9 @@ pub fn add_array_functions(env: &mut Environment) {
         // Compute keys for each element
         let mut keyed: Vec<(Value, Value)> = Vec::new();
         for value in a {
-            let mut ctx = c.ctx.clone();
-            ctx.insert("#".to_string(), value.clone());
-            let key = c.env.run(predicate.clone(), &ctx)?;
+            let key = c
+                .env
+                .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?;
             keyed.push((key, value.clone()));
         }
         keyed.sort_by(|(a, _), (b, _)| {
@@ -267,7 +285,11 @@ pub fn add_array_functions(env: &mut Environment) {
                 (Value::String(a), Value::String(b)) => a.cmp(b),
                 (a, b) => a.to_string().cmp(&b.to_string()),
             };
-            if desc { cmp.reverse() } else { cmp }
+            if desc {
+                cmp.reverse()
+            } else {
+                cmp
+            }
         });
         Ok(keyed.into_iter().map(|(_, v)| v).collect::<Vec<_>>().into())
     });

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -7,7 +7,7 @@ pub mod string;
 use crate::Result;
 
 use crate::ast::program::Program;
-use crate::{bail, Context, Environment, Value};
+use crate::{bail, ContextProvider, Environment, Value};
 
 pub type Function<'a> = Box<dyn Fn(ExprCall) -> Result<Value> + 'a + Sync + Send>;
 
@@ -15,12 +15,18 @@ pub struct ExprCall<'a, 'b> {
     pub ident: String,
     pub args: Vec<Value>,
     pub predicate: Option<Program>,
-    pub ctx: &'a Context,
+    pub ctx: &'a dyn ContextProvider,
     pub env: &'a Environment<'b>,
 }
 
 impl Environment<'_> {
-    pub fn eval_func(&self, ctx: &Context, ident: String, args: Vec<Value>, predicate: Option<Program>) -> Result<Value> {
+    pub fn eval_func(
+        &self,
+        ctx: &dyn ContextProvider,
+        ident: String,
+        args: Vec<Value>,
+        predicate: Option<Program>,
+    ) -> Result<Value> {
         let call = ExprCall {
             ident,
             args,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod serde;
 mod test;
 mod value;
 
-pub use crate::context::Context;
+pub use crate::context::{Context, ContextProvider};
 pub use crate::error::{Error, Result};
 pub use crate::eval::{Environment, run, eval};
 pub use crate::parser::compile;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,8 +2,8 @@ use crate::ast::node::Node;
 use crate::ast::program::Program;
 use crate::eval::Environment;
 use crate::functions::ExprCall;
+use crate::{ContextProvider, Error, Result, Value};
 use crate::{ExprPest, Rule};
-use crate::{Context, Error, Result, Value};
 use pest::Parser as PestParser;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -83,7 +83,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Run a compiled expr program
-    pub fn run(&self, program: Program, ctx: &Context) -> Result<Value> {
+    pub fn run(&self, program: Program, ctx: &dyn ContextProvider) -> Result<Value> {
         self.env.run(program, ctx)
     }
 
@@ -97,11 +97,11 @@ impl<'a> Parser<'a> {
     /// let ctx = Context::default();
     /// assert_eq!(p.eval("1 + 2", &ctx).unwrap().to_string(), "3");
     /// ```
-    pub fn eval(&self, code: &str, ctx: &Context) -> Result<Value> {
+    pub fn eval(&self, code: &str, ctx: &dyn ContextProvider) -> Result<Value> {
         self.env.eval(code, ctx)
     }
 
-    pub fn eval_expr(&self, ctx: &Context, node: Node) -> Result<Value> {
+    pub fn eval_expr(&self, ctx: &dyn ContextProvider, node: Node) -> Result<Value> {
         self.env.eval_expr(ctx, node)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Value};
+use crate::{Context, ContextProvider, Value};
 use crate::{Environment, eval};
 #[allow(deprecated)]
 use crate::Parser;
@@ -88,6 +88,51 @@ fn logical_operators_are_strict_and_short_circuit() -> Result<()> {
     assert!(eval("1 or true", &context).is_err());
     assert_eq!(eval("false and unknown", &context)?, Value::Bool(false));
     assert_eq!(eval("true or unknown", &context)?, Value::Bool(true));
+    Ok(())
+}
+
+#[test]
+fn default_environment_includes_builtins() -> Result<()> {
+    let context = Context::default();
+    assert_eq!(
+        Environment::default().eval("len([1, 2])", &context)?,
+        Value::Integer(2)
+    );
+    #[allow(deprecated)]
+    let parser = Parser::default();
+    assert_eq!(parser.eval("string(3)", &context)?, Value::from("3"));
+    Ok(())
+}
+
+#[test]
+fn context_is_materialized_only_for_env() -> Result<()> {
+    use std::cell::Cell;
+
+    struct CountingContext {
+        context: Context,
+        materializations: Cell<usize>,
+    }
+
+    impl ContextProvider for CountingContext {
+        fn get(&self, key: &str) -> Option<&Value> {
+            self.context.get(key)
+        }
+
+        fn to_context(&self) -> Context {
+            self.materializations
+                .set(self.materializations.get() + 1);
+            self.context.clone()
+        }
+    }
+
+    let context = CountingContext {
+        context: Context::from_iter([("answer", 42)]),
+        materializations: Cell::new(0),
+    };
+    assert_eq!(eval("answer", &context)?, Value::Integer(42));
+    assert_eq!(context.materializations.get(), 0);
+    assert_eq!(eval("$env.answer", &context)?, Value::Integer(42));
+    assert_eq!(context.materializations.get(), 1);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- introduce `ContextProvider` so evaluation and custom functions can borrow context data
- replace full-context clones with small local scopes for assignments and array predicates
- materialize `$env` lazily only when it is referenced
- add `Context::from_serialize` and `TryFrom<Value>` for map/struct context construction
- make `Environment::default()` and deprecated `Parser::default()` include the same built-ins as `new()`

## Why

The #9 benchmark showed context cloning dominates evaluation for large inputs. With a precompiled lookup against 100,000 entries, this branch measures about 98 ns/run instead of roughly 27 ms/run on the same machine. The serde constructor is the concrete API proposed for #5, while the default implementation removes the surprising empty-environment behavior from #10.

## Breaking API

`eval`, `run`, evaluator internals, and `ExprCall::ctx` now accept `&dyn ContextProvider`. Existing `&Context` call sites continue to coerce automatically; custom functions that cloned `ExprCall::ctx` should call `to_context()` when they truly need ownership.

## Stack

- built on the operator PR above it; merge #72 and the operator PR first

## Checks

- `cargo test` (104 unit tests, 10 doctests)
- `cargo test --all-features` (110 unit tests, 10 doctests)
- `git diff --check`
- release-mode 100,000-entry context benchmark
- `cargo clippy --all-features -- -D warnings` reaches only two pre-existing `useless_borrows_in_formatting` warnings in `src/ast/node.rs` and `src/value.rs`

Fixed #5.
Fixed #9.
Fixed #10.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API surface for custom functions and eval entry points; core evaluation semantics change around `$env` and scoped bindings, though behavior is covered by new tests.
> 
> **Overview**
> **Breaking:** `eval`, `run`, `Environment`, `Parser`, and `ExprCall::ctx` now take `&dyn ContextProvider` instead of `&Context`. Existing `&Context` call sites still work via trait coercion.
> 
> Introduces **`ContextProvider`** so evaluation can borrow context data instead of cloning whole maps on every run. **`ContextScope`** layers local bindings (program `let` lines and predicate `#`) on top of a parent provider; array builtins (`map`, `filter`, `all`, etc.) use **`run_with_binding`** instead of cloning context per element.
> 
> **`$env`** is built only when referenced (`ctx.environment()`), not by cloning the full context at the start of `run`.
> 
> Adds **`Context::from_serialize`** (serde feature) and **`TryFrom<Value>`** for map-backed contexts. **`Environment::default()`** now matches **`new()`** (built-in functions), fixing empty default environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae406613cbf8d4a98ffe3acbe436c6dffd22fb24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->