### PR TITLE
docs: document v2 status and migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/jdx/expr.rs"
 repository = "https://github.com/jdx/expr.rs"
 description = "Implementation of expr language in Rust"
 include = [
+    "/MIGRATION.md",
     "/src/**/*.pest",
     "/src/**/*.rs",
 ]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,62 @@
+# Migrating from v1 to v2
+
+Version 2 makes several intentional compatibility and API corrections. Most
+callers only need to update the integer variant and accessor names.
+
+## Integer values
+
+`Value::Number` is now `Value::Integer`, and `Value::as_number()` is now
+`Value::as_integer()`. This distinguishes integral values from `Value::Float`
+without changing their `i64` representation.
+
+```rust
+let value = expr::Value::Integer(2);
+assert_eq!(value.as_integer(), Some(2));
+```
+
+## Operator behavior
+
+Mixed integer and float arithmetic, comparison, and equality now promote the
+integer operand to a float. Logical `and` and `or` require boolean operands and
+short-circuit evaluation. Code that relied on non-boolean truthiness must use an
+explicit comparison instead.
+
+The Go expr-compatible `bitand`, `bitor`, `bitxor`, `bitnand`, `bitnot`,
+`bitshl`, `bitshr`, and `bitushr` functions are available in the default
+environment.
+
+## Borrowed contexts
+
+Evaluation accepts `&dyn ContextProvider` rather than requiring `&Context`.
+Existing calls that pass `&Context` do not need to change. `ExprCall::ctx` is
+also a borrowed provider, so custom functions that previously cloned it should
+look values up directly:
+
+```rust
+env.add_function("region", |call| {
+    Ok(call.ctx.get("region").cloned().unwrap_or_default())
+});
+```
+
+Call `call.ctx.to_context()` only when the custom function requires an owned
+snapshot. Ordinary evaluation no longer clones the entire input context, and
+`$env` materializes a snapshot only when referenced.
+
+With the `serde` feature enabled, maps and structs can become contexts directly:
+
+```rust
+#[derive(serde::Serialize)]
+struct Input<'a> {
+    name: &'a str,
+}
+
+let context = expr::Context::from_serialize(&Input { name: "mise" })?;
+# Ok::<(), expr::Error>(())
+```
+
+## Default environments
+
+`Environment::default()` now behaves like `Environment::new()` and includes all
+built-in functions. The deprecated `Parser::default()` receives the same fix.
+Use an explicitly constructed custom environment if an empty function registry
+is required.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Implementation of [expr](https://expr-lang.org/) in rust.
 
+## Project status
+
+`expr-lang` is actively maintained for use in [mise](https://mise.jdx.dev/) and
+other Rust applications. The next release will be v2.
+
+Language support is not yet complete. The v2 goal is source-level compatibility
+with the Go implementation of expr for the syntax and built-ins this crate
+supports. Differences in those supported areas are treated as bugs unless they
+are documented. See the [issue tracker](https://github.com/jdx/expr.rs/issues)
+for known gaps.
+
+Evaluation is currently tree-walking. Bytecode compilation is not planned for
+v2; correctness, compatibility, and a small embeddable API take priority. A
+bytecode backend could be considered later if real-world profiling shows that
+evaluation itself is a bottleneck.
+
+See [MIGRATION.md](MIGRATION.md) when upgrading from v1 to v2.
+
 ## Usage
 
 ```rust
@@ -34,7 +52,7 @@ fn main() {
 
 ```toml
 [dependencies]
-expr-lang = { version = "0.3", features = ["serde"] }
+expr-lang = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 ```
 
@@ -42,7 +60,7 @@ serde = { version = "1.0", features = ["derive"] }
 use expr::{Value, to_value, from_value};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Foo {
     a: i64,
     b: String,
@@ -55,9 +73,9 @@ fn main() {
     };
 
     let value: Value = to_value(&foo).unwrap();
-    assert_eq!(value, Value::Map(IndexMap::from([
-        ("a".to_string(), Value::Integer(1)),
-    ])));
+    let map = value.as_map().unwrap();
+    assert_eq!(map.get("a"), Some(&Value::Integer(1)));
+    assert_eq!(map.get("b"), Some(&Value::String("hello".to_string())));
     assert_eq!(from_value::<Foo>(value).unwrap(), foo);
 }
 ```
@@ -66,7 +84,7 @@ fn main() {
 
 ```toml
 [dependencies]
-expr-lang = { version = "0.3", features = ["serde"] }
+expr-lang = { version = "1", features = ["serde"] }
 serde_json = "1.0"
 ```
 
@@ -81,9 +99,9 @@ fn main() {
     }"#;
 
     let value: Value = from_str(json).unwrap();
-    assert_eq!(value, Value::Map(IndexMap::from([
-        ("a".to_string(), Value::Integer(1)),
-    ])));
+    let map = value.as_map().unwrap();
+    assert_eq!(map.get("a"), Some(&Value::Integer(1)));
+    assert_eq!(map.get("b"), Some(&Value::String("hello".to_string())));
     assert_eq!(to_string(&value).unwrap(), r#"{\"a\":1,\"b\":\"hello\"}"#);
 }
 ```


### PR DESCRIPTION
## Summary

- describe the crate as actively maintained and v2 as the next release
- state that language coverage is incomplete and define source-level Go expr compatibility as the direction
- document that bytecode is not planned for v2 and explain the current priorities
- add a v1-to-v2 migration guide covering integer naming, operators, borrowed contexts, serde contexts, and default environments
- refresh stale serde dependency examples and assertions

## Why

This answers the project-status questions in #4 and gives users one place to prepare for the intentionally breaking v2 stack.

## Stack

- built on the three implementation PRs below it; merge those first

## Checks

- `cargo test --all-features` (110 unit tests, 10 doctests)
- `git diff --check`

Fixed #4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and packaging include-list only; no runtime or API code changes in this diff.
> 
> **Overview**
> Adds **project status** to the README: active maintenance for mise, v2 as the next release, Go-compatible runtime semantics as the direction, tree-walking evaluation (no bytecode in v2), and a link to the new migration guide.
> 
> Introduces **`MIGRATION.md`** covering v2 breaking/API changes: `Value::Number` → `Value::Integer` / `as_integer()`, mixed int/float promotion and strict boolean `and`/`or`, bitwise built-ins, borrowed `ContextProvider` / `ExprCall::ctx` (and optional `from_serialize`), and `Environment::default()` matching `new()` with full built-ins.
> 
> Updates README **serde examples** to depend on `expr-lang` **1** and assert via `as_map()` / `Value::Integer` instead of stale `0.3` and partial map equality. Ships `MIGRATION.md` in the crate via **`Cargo.toml` `include`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a537d9353d44fbdb18fd16cfe83d9687730427db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->