### PR TITLE
test: add go expr compatibility corpus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/jdx/expr.rs"
 repository = "https://github.com/jdx/expr.rs"
 description = "Implementation of expr language in Rust"
 include = [
+    "/compat/cases.tsv",
     "/MIGRATION.md",
     "/src/**/*.pest",
     "/src/**/*.rs",

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ Implementation of [expr](https://expr-lang.org/) in rust.
 `expr-lang` is actively maintained for use in [mise](https://mise.jdx.dev/) and
 other Rust applications. The next release will be v2.
 
-Language support is not yet complete. The v2 goal is source-level compatibility
-with the Go implementation of expr for the syntax and built-ins this crate
-supports. Differences in those supported areas are treated as bugs unless they
-are documented. See the [issue tracker](https://github.com/jdx/expr.rs/issues)
-for known gaps.
+`expr-lang` implements the core expr syntax and built-ins used by mise. Version
+2 targets Go-compatible runtime semantics and is expanding toward complete
+expression-language parity. Go-specific reflection, static type checking,
+optimization, and bytecode execution are outside that compatibility target.
 
 Evaluation is currently tree-walking. Bytecode compilation is not planned for
 v2; correctness, compatibility, and a small embeddable API take priority. A

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,19 @@
+# Go expr compatibility corpus
+
+`cases.tsv` records expression results from Go expr v1.17.8. Both runners
+evaluate the expressions directly and compare their results as JSON values, so
+object key order does not affect compatibility checks.
+
+After changing or adding cases, verify the expectations against the pinned Go
+implementation:
+
+```sh
+cd compat
+go run .
+```
+
+Then run the Rust side from the repository root:
+
+```sh
+cargo test --test go_compat
+```

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -1,0 +1,40 @@
+# expression<TAB>canonical JSON result
+nil	null
+true	true
+42	42
+1.5	1.5
+"hello"	"hello"
+[1, 2, 3]	[1,2,3]
+{a: 1, b: "two"}	{"a":1,"b":"two"}
+{b: "two", a: 1}	{"a":1,"b":"two"}
+1 + 2 * 3	7
+2 ** 3	8
+1 + 0.5	1.5
+1 == 1.0	true
+1 < 1.5	true
+false and unknown	false
+true or unknown	true
+nil ?? "fallback"	"fallback"
+true ? "yes" : "no"	"yes"
+[1, 2, 3][-1]	3
+[1, 2, 3, 4][1:3]	[2,3]
+2 in [1, 2, 3]	true
+"hello" startsWith "he"	true
+"hello" matches "^h"	true
+1..3	[1,2,3]
+let x = 2; x * 3	6
+upper("mise")	"MISE"
+split("a,b", ",")	["a","b"]
+split("a;b", ";")	["a","b"]
+map([1, 2, 3], {# * 2})	[2,4,6]
+filter([1, 2, 3], {# > 1})	[2,3]
+find([1, 2, 3], {# > 1})	2
+sort([3, 1, 2])	[1,2,3]
+sort(keys({a: 1, b: 2}))	["a","b"]
+len({a: 1, b: 2})	2
+int("42")	42
+float("1.5")	1.5
+float(5)	5
+string(42)	"42"
+bitand(14, 11)	10
+bitushr(-5, 2)	4611686018427387902

--- a/compat/go.mod
+++ b/compat/go.mod
@@ -1,0 +1,5 @@
+module expr-rs-compat
+
+go 1.24
+
+require github.com/expr-lang/expr v1.17.8

--- a/compat/go.sum
+++ b/compat/go.sum
@@ -1,0 +1,2 @@
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=

--- a/compat/main.go
+++ b/compat/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	goexpr "github.com/expr-lang/expr"
+)
+
+func main() {
+	file, err := os.Open("cases.tsv")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := scanner.Text()
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+		parts := strings.SplitN(text, "\t", 2)
+		if len(parts) != 2 {
+			panic(fmt.Sprintf("cases.tsv:%d: expected expression and result", line))
+		}
+		program, err := goexpr.Compile(parts[0])
+		if err != nil {
+			panic(fmt.Sprintf("cases.tsv:%d: %v", line, err))
+		}
+		result, err := goexpr.Run(program, nil)
+		if err != nil {
+			panic(fmt.Sprintf("cases.tsv:%d: %v", line, err))
+		}
+		actual, err := json.Marshal(result)
+		if err != nil {
+			panic(fmt.Sprintf("cases.tsv:%d: %v", line, err))
+		}
+		var expected any
+		decoder := json.NewDecoder(strings.NewReader(parts[1]))
+		decoder.UseNumber()
+		if err := decoder.Decode(&expected); err != nil {
+			panic(fmt.Sprintf("cases.tsv:%d: invalid expected JSON: %v", line, err))
+		}
+		want, err := json.Marshal(expected)
+		if err != nil {
+			panic(fmt.Sprintf("cases.tsv:%d: %v", line, err))
+		}
+		if string(actual) != string(want) {
+			panic(fmt.Sprintf("cases.tsv:%d: got %s, want %s", line, actual, want))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+	fmt.Printf("verified %d lines against Go expr v1.17.8\n", line)
+}

--- a/tests/go_compat.rs
+++ b/tests/go_compat.rs
@@ -1,0 +1,82 @@
+use expr::{eval, Context, Value as ExprValue};
+use serde_json::{Map, Number, Value as JsonValue};
+
+fn json_value(value: ExprValue) -> JsonValue {
+    match value {
+        ExprValue::Nil => JsonValue::Null,
+        ExprValue::Bool(value) => JsonValue::Bool(value),
+        ExprValue::Integer(value) => JsonValue::Number(value.into()),
+        ExprValue::Float(value) => Number::from_f64(value)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        ExprValue::String(value) => JsonValue::String(value),
+        ExprValue::Array(values) => JsonValue::Array(values.into_iter().map(json_value).collect()),
+        ExprValue::Map(values) => JsonValue::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, json_value(value)))
+                .collect::<Map<_, _>>(),
+        ),
+    }
+}
+
+fn json_values_equal(left: &JsonValue, right: &JsonValue) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left, right) {
+        (JsonValue::Number(left), JsonValue::Number(right)) => {
+            (left.is_f64() || right.is_f64()) && left.as_f64() == right.as_f64()
+        }
+        (JsonValue::Array(left), JsonValue::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| json_values_equal(left, right))
+        }
+        (JsonValue::Object(left), JsonValue::Object(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(key, left)| {
+                    right
+                        .get(key)
+                        .is_some_and(|right| json_values_equal(left, right))
+                })
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn json_comparison_preserves_integer_precision() {
+    let left = serde_json::from_str::<JsonValue>("9007199254740992").unwrap();
+    let right = serde_json::from_str::<JsonValue>("9007199254740993").unwrap();
+    assert!(!json_values_equal(&left, &right));
+
+    let float = serde_json::from_str::<JsonValue>("5.0").unwrap();
+    let integer = serde_json::from_str::<JsonValue>("5").unwrap();
+    assert!(json_values_equal(&float, &integer));
+}
+
+#[test]
+fn matches_go_expr_v1_17_8_corpus() {
+    let context = Context::default();
+    for (index, line) in include_str!("../compat/cases.tsv").lines().enumerate() {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (expression, expected) = line
+            .split_once('\t')
+            .unwrap_or_else(|| panic!("compat/cases.tsv:{}: invalid case", index + 1));
+        let actual = eval(expression, &context)
+            .unwrap_or_else(|error| panic!("compat/cases.tsv:{}: {error}", index + 1));
+        let expected = serde_json::from_str::<JsonValue>(expected)
+            .unwrap_or_else(|error| panic!("compat/cases.tsv:{}: {error}", index + 1));
+        let actual = json_value(actual);
+        assert!(
+            json_values_equal(&actual, &expected),
+            "compat/cases.tsv:{}: {expression}: got {actual}, want {expected}",
+            index + 1,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared TSV corpus of expressions and canonical JSON results
- pin the reference implementation to Go expr v1.17.8
- add a Go verifier for refreshing and validating corpus expectations
- replay the same corpus as a Rust integration test

## Why

The v2 compatibility target needs an executable definition. This creates a differential test foundation that future syntax and built-in PRs can extend case by case.

## Impact

There is no runtime API change. The published crate includes the corpus, while the Go verifier remains a development tool.

## Stack

- built on #80 and the implementation PRs below it

## Checks

- `mise x go@1.25.12 -- go run .` in `compat/`
- `cargo test --test go_compat`
- `cargo test --all-features` (110 unit tests, 1 compatibility test, 10 doctests)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes; published artifact only gains the corpus file, with no evaluator or public API modifications.
> 
> **Overview**
> Adds an **executable Go parity baseline** for v2: a shared `compat/cases.tsv` (expression → canonical JSON), a **pinned Go expr v1.17.8** verifier under `compat/`, and a Rust integration test `cargo test --test go_compat` that evaluates the same cases and compares JSON (with tolerant number/object equality).
> 
> The corpus is **shipped in the crate** via `Cargo.toml` `include`; the Go runner stays a dev tool. **README** project status is tightened to describe v2 as Go-compatible runtime semantics without Go reflection/typecheck/bytecode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a75069a14871750c4e539019561efd858167aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->