### PR TITLE
feat(lib): add numeric and utility built-ins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +148,7 @@ dependencies = [
 name = "expr-lang"
 version = "1.1.1"
 dependencies = [
+ "base64",
  "indexmap",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = ["dep:serde", "indexmap/serde"]
 name = "expr"
 
 [dependencies]
+base64 = "0.22"
 indexmap = "2"
 regex = "1"
 thiserror = "2"

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -52,17 +52,25 @@ bitushr(-5, 2)	4611686018427387902
 max(5, 7)	7
 min(5, 7)	5
 max(1.5, 2)	2
+max(9007199254740992, 9007199254740993)	9007199254740993
+min(9007199254740993, 9007199254740992)	9007199254740992
+type(max(1.5, 2))	"int"
 abs(-5)	5
 abs(-1.5)	1.5
 ceil(1.5)	2
 floor(1.5)	1
 round(1.5)	2
 round(-1.5)	-2
+type(ceil(2))	"float"
+max([1, [5, 3]], 4)	5
+mean([1, 2, 3, 4])	2.5
+median([4, 1, 3, 2])	2.5
 type(nil)	"nil"
 type(42)	"int"
 type(1.5)	"float"
 type([1])	"array"
 get([1, 2], 1)	2
+get([1, 2], -1)	2
 get([1, 2], 9)	null
 get({a: 1}, "a")	1
 get({a: 1}, "missing")	null

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -49,3 +49,24 @@ bitushr(-5, 2)	4611686018427387902
 {"display-name": "mise"}["display-name"]	"mise"
 [1, 2,]	[1,2]
 {a: 1,}	{"a":1}
+max(5, 7)	7
+min(5, 7)	5
+max(1.5, 2)	2
+abs(-5)	5
+abs(-1.5)	1.5
+ceil(1.5)	2
+floor(1.5)	1
+round(1.5)	2
+round(-1.5)	-2
+type(nil)	"nil"
+type(42)	"int"
+type(1.5)	"float"
+type([1])	"array"
+get([1, 2], 1)	2
+get([1, 2], 9)	null
+get({a: 1}, "a")	1
+get({a: 1}, "missing")	null
+toBase64("Hello World")	"SGVsbG8gV29ybGQ="
+fromBase64("SGVsbG8gV29ybGQ=")	"Hello World"
+sortBy(toPairs({a: 1, b: 2}), {#[0]})	[["a",1],["b",2]]
+fromPairs([["a", 1], ["b", 2]]).b	2

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,7 +1,7 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
 use crate::context::ContextScope;
-use crate::functions::{array, bitwise, convert, json, string, ExprCall, Function};
+use crate::functions::{array, bitwise, convert, json, misc, number, string, ExprCall, Function};
 use crate::parser::compile;
 use crate::{bail, ContextProvider, Result, Value};
 use indexmap::IndexMap;
@@ -75,6 +75,8 @@ impl<'a> Environment<'a> {
         bitwise::add_bitwise_functions(&mut p);
         convert::add_conversion_functions(&mut p);
         json::add_json_functions(&mut p);
+        misc::add_misc_functions(&mut p);
+        number::add_number_functions(&mut p);
         p
     }
 

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -30,11 +30,19 @@ pub fn add_misc_functions(env: &mut Environment) {
             bail!("get() takes exactly two arguments");
         }
         match (&call.args[0], &call.args[1]) {
-            (Value::Array(values), Value::Integer(index)) => Ok(usize::try_from(*index)
-                .ok()
+            (Value::Array(values), Value::Integer(index)) => {
+                let index = if *index < 0 {
+                    usize::try_from(index.unsigned_abs())
+                        .ok()
+                        .and_then(|offset| values.len().checked_sub(offset))
+                } else {
+                    usize::try_from(*index).ok()
+                };
+                Ok(index
                 .and_then(|index| values.get(index))
                 .cloned()
-                .unwrap_or_default()),
+                    .unwrap_or_default())
+            }
             (Value::Map(values), Value::String(key)) => {
                 Ok(values.get(key).cloned().unwrap_or_default())
             }

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -1,0 +1,91 @@
+use crate::{Environment, Error, Value, bail};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use indexmap::IndexMap;
+
+fn one_argument(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
+    if args.len() != 1 {
+        bail!("{name}() takes exactly one argument");
+    }
+    Ok(args.pop().expect("length checked"))
+}
+
+/// Add Go expr-compatible miscellaneous and collection conversion functions.
+pub fn add_misc_functions(env: &mut Environment) {
+    env.add_function("type", |call| {
+        let name = match one_argument("type", call.args)? {
+            Value::Nil => "nil",
+            Value::Bool(_) => "bool",
+            Value::Integer(_) => "int",
+            Value::Float(_) => "float",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Map(_) => "map",
+        };
+        Ok(Value::from(name))
+    });
+
+    env.add_function("get", |call| {
+        if call.args.len() != 2 {
+            bail!("get() takes exactly two arguments");
+        }
+        match (&call.args[0], &call.args[1]) {
+            (Value::Array(values), Value::Integer(index)) => Ok(usize::try_from(*index)
+                .ok()
+                .and_then(|index| values.get(index))
+                .cloned()
+                .unwrap_or_default()),
+            (Value::Map(values), Value::String(key)) => {
+                Ok(values.get(key).cloned().unwrap_or_default())
+            }
+            _ => bail!("get() takes an array and integer or a map and string"),
+        }
+    });
+
+    env.add_function("toBase64", |call| match one_argument("toBase64", call.args)? {
+        Value::String(value) => Ok(Value::from(STANDARD.encode(value))),
+        _ => bail!("toBase64() takes a string as the argument"),
+    });
+    env.add_function("fromBase64", |call| match one_argument("fromBase64", call.args)? {
+        Value::String(value) => {
+            let decoded = STANDARD
+                .decode(value)
+                .map_err(|error| Error::ExprError(format!("fromBase64() invalid input: {error}")))?;
+            let decoded = String::from_utf8(decoded)
+                .map_err(|error| {
+                    Error::ExprError(format!("fromBase64() decoded non-UTF-8 data: {error}"))
+                })?;
+            Ok(Value::from(decoded))
+        }
+        _ => bail!("fromBase64() takes a string as the argument"),
+    });
+
+    env.add_function("toPairs", |call| match one_argument("toPairs", call.args)? {
+        Value::Map(values) => Ok(Value::Array(
+            values
+                .into_iter()
+                .map(|(key, value)| Value::Array(vec![Value::from(key), value]))
+                .collect(),
+        )),
+        _ => bail!("toPairs() takes a map as the argument"),
+    });
+    env.add_function("fromPairs", |call| match one_argument("fromPairs", call.args)? {
+        Value::Array(pairs) => {
+            let mut values = IndexMap::new();
+            for pair in pairs {
+                match pair {
+                    Value::Array(pair) if pair.len() == 2 => {
+                        let mut pair = pair.into_iter();
+                        let Value::String(key) = pair.next().expect("length checked") else {
+                            bail!("fromPairs() pair keys must be strings");
+                        };
+                        values.insert(key, pair.next().expect("length checked"));
+                    }
+                    _ => bail!("fromPairs() expects an array of two-element arrays"),
+                }
+            }
+            Ok(Value::Map(values))
+        }
+        _ => bail!("fromPairs() takes an array as the argument"),
+    });
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -2,6 +2,8 @@ pub mod array;
 pub mod bitwise;
 pub mod convert;
 pub mod json;
+pub mod misc;
+pub mod number;
 pub mod string;
 
 use crate::Result;

--- a/src/functions/number.rs
+++ b/src/functions/number.rs
@@ -1,4 +1,5 @@
 use crate::{Environment, Value, bail};
+use std::cmp::Ordering;
 
 fn one_number(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
     if args.len() != 1 {
@@ -10,40 +11,86 @@ fn one_number(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
     }
 }
 
-fn two_numbers(name: &str, args: Vec<Value>) -> crate::Result<(Value, Value)> {
-    if args.len() != 2 {
-        bail!("{name}() takes exactly two arguments");
+fn collect_numbers(name: &str, value: Value, numbers: &mut Vec<Value>) -> crate::Result<()> {
+    match value {
+        value @ (Value::Integer(_) | Value::Float(_)) => numbers.push(value),
+        Value::Array(values) => {
+            for value in values {
+                collect_numbers(name, value, numbers)?;
+            }
+        }
+        _ => bail!("invalid argument for {name} (expected number or array)"),
     }
-    let mut args = args.into_iter();
-    let left = args.next().expect("length checked");
-    let right = args.next().expect("length checked");
-    if !matches!(left, Value::Integer(_) | Value::Float(_))
-        || !matches!(right, Value::Integer(_) | Value::Float(_))
-    {
-        bail!("{name}() takes numbers as arguments");
+    Ok(())
+}
+
+fn as_float(value: &Value) -> f64 {
+    match value {
+        Value::Integer(value) => *value as f64,
+        Value::Float(value) => *value,
+        _ => unreachable!("collected numeric value"),
     }
-    Ok((left, right))
+}
+
+fn compare_integer_float(integer: i64, float: f64) -> Ordering {
+    if float.is_nan() {
+        return Ordering::Equal;
+    }
+    if float < i64::MIN as f64 {
+        return Ordering::Greater;
+    }
+    if float >= 9_223_372_036_854_775_808.0 {
+        return Ordering::Less;
+    }
+
+    let truncated = float as i64;
+    match integer.cmp(&truncated) {
+        Ordering::Equal if float.fract() > 0.0 => Ordering::Less,
+        Ordering::Equal if float.fract() < 0.0 => Ordering::Greater,
+        ordering => ordering,
+    }
+}
+
+fn compare_numbers(left: &Value, right: &Value) -> Ordering {
+    match (left, right) {
+        (Value::Integer(left), Value::Integer(right)) => left.cmp(right),
+        (Value::Integer(left), Value::Float(right)) => compare_integer_float(*left, *right),
+        (Value::Float(left), Value::Integer(right)) => compare_integer_float(*right, *left).reverse(),
+        (Value::Float(left), Value::Float(right)) => {
+            left.partial_cmp(right).unwrap_or(Ordering::Equal)
+        }
+        _ => unreachable!("collected numeric value"),
+    }
+}
+
+fn numbers(name: &str, args: Vec<Value>) -> crate::Result<Vec<Value>> {
+    if args.is_empty() {
+        bail!("not enough arguments to call {name}");
+    }
+    let mut numbers = Vec::new();
+    for value in args {
+        collect_numbers(name, value, &mut numbers)?;
+    }
+    Ok(numbers)
 }
 
 fn extrema(name: &str, args: Vec<Value>, maximum: bool) -> crate::Result<Value> {
-    let (left, right) = two_numbers(name, args)?;
-    Ok(match (left, right) {
-        (Value::Integer(left), Value::Integer(right)) => {
-            Value::Integer(if maximum { left.max(right) } else { left.min(right) })
+    let mut numbers = numbers(name, args)?.into_iter();
+    let Some(mut result) = numbers.next() else {
+        return Ok(Value::Nil);
+    };
+    for value in numbers {
+        let ordering = compare_numbers(&value, &result);
+        let replace = if maximum {
+            ordering.is_gt()
+        } else {
+            ordering.is_lt()
+        };
+        if replace {
+            result = value;
         }
-        (Value::Integer(left), Value::Float(right)) => {
-            let left = left as f64;
-            Value::Float(if maximum { left.max(right) } else { left.min(right) })
-        }
-        (Value::Float(left), Value::Integer(right)) => {
-            let right = right as f64;
-            Value::Float(if maximum { left.max(right) } else { left.min(right) })
-        }
-        (Value::Float(left), Value::Float(right)) => {
-            Value::Float(if maximum { left.max(right) } else { left.min(right) })
-        }
-        _ => unreachable!("validated numeric arguments"),
-    })
+    }
+    Ok(result)
 }
 
 /// Add Go expr-compatible numeric functions.
@@ -58,16 +105,62 @@ pub fn add_number_functions(env: &mut Environment) {
         Value::Float(value) => Ok(Value::Float(value.abs())),
         _ => unreachable!("validated numeric argument"),
     });
-    env.add_function("ceil", |call| match one_number("ceil", call.args)? {
-        Value::Float(value) => Ok(Value::Float(value.ceil())),
-        _ => bail!("ceil() takes a float as the argument"),
+    env.add_function("ceil", |call| {
+        Ok(Value::Float(
+            as_float(&one_number("ceil", call.args)?).ceil(),
+        ))
     });
-    env.add_function("floor", |call| match one_number("floor", call.args)? {
-        Value::Float(value) => Ok(Value::Float(value.floor())),
-        _ => bail!("floor() takes a float as the argument"),
+    env.add_function("floor", |call| {
+        Ok(Value::Float(
+            as_float(&one_number("floor", call.args)?).floor(),
+        ))
     });
-    env.add_function("round", |call| match one_number("round", call.args)? {
-        Value::Float(value) => Ok(Value::Float(value.round())),
-        _ => bail!("round() takes a float as the argument"),
+    env.add_function("round", |call| {
+        Ok(Value::Float(
+            as_float(&one_number("round", call.args)?).round(),
+        ))
     });
+    env.add_function("mean", |call| {
+        let numbers = numbers("mean", call.args)?;
+        if numbers.is_empty() {
+            return Ok(Value::Float(0.0));
+        }
+        let mean = numbers.iter().map(as_float).sum::<f64>() / numbers.len() as f64;
+        Ok(Value::Float(mean))
+    });
+    env.add_function("median", |call| {
+        let mut numbers = numbers("median", call.args)?
+            .iter()
+            .map(as_float)
+            .collect::<Vec<_>>();
+        if numbers.is_empty() {
+            return Ok(Value::Float(0.0));
+        }
+        numbers.sort_by(f64::total_cmp);
+        let middle = numbers.len() / 2;
+        let median = if numbers.len() % 2 == 0 {
+            (numbers[middle - 1] + numbers[middle]) / 2.0
+        } else {
+            numbers[middle]
+        };
+        Ok(Value::Float(median))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Context, Value, eval};
+
+    #[test]
+    fn extrema_preserve_mixed_numeric_order_above_f64_precision() {
+        let context = Context::default();
+        assert_eq!(
+            eval("max(9007199254740992.0, 9007199254740993)", &context).unwrap(),
+            Value::Integer(9_007_199_254_740_993)
+        );
+        assert_eq!(
+            eval("min(9007199254740993, 9007199254740992.0)", &context).unwrap(),
+            Value::Float(9_007_199_254_740_992.0)
+        );
+    }
 }

--- a/src/functions/number.rs
+++ b/src/functions/number.rs
@@ -1,0 +1,73 @@
+use crate::{Environment, Value, bail};
+
+fn one_number(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
+    if args.len() != 1 {
+        bail!("{name}() takes exactly one argument");
+    }
+    match args.pop().expect("length checked") {
+        value @ (Value::Integer(_) | Value::Float(_)) => Ok(value),
+        _ => bail!("{name}() takes a number as the argument"),
+    }
+}
+
+fn two_numbers(name: &str, args: Vec<Value>) -> crate::Result<(Value, Value)> {
+    if args.len() != 2 {
+        bail!("{name}() takes exactly two arguments");
+    }
+    let mut args = args.into_iter();
+    let left = args.next().expect("length checked");
+    let right = args.next().expect("length checked");
+    if !matches!(left, Value::Integer(_) | Value::Float(_))
+        || !matches!(right, Value::Integer(_) | Value::Float(_))
+    {
+        bail!("{name}() takes numbers as arguments");
+    }
+    Ok((left, right))
+}
+
+fn extrema(name: &str, args: Vec<Value>, maximum: bool) -> crate::Result<Value> {
+    let (left, right) = two_numbers(name, args)?;
+    Ok(match (left, right) {
+        (Value::Integer(left), Value::Integer(right)) => {
+            Value::Integer(if maximum { left.max(right) } else { left.min(right) })
+        }
+        (Value::Integer(left), Value::Float(right)) => {
+            let left = left as f64;
+            Value::Float(if maximum { left.max(right) } else { left.min(right) })
+        }
+        (Value::Float(left), Value::Integer(right)) => {
+            let right = right as f64;
+            Value::Float(if maximum { left.max(right) } else { left.min(right) })
+        }
+        (Value::Float(left), Value::Float(right)) => {
+            Value::Float(if maximum { left.max(right) } else { left.min(right) })
+        }
+        _ => unreachable!("validated numeric arguments"),
+    })
+}
+
+/// Add Go expr-compatible numeric functions.
+pub fn add_number_functions(env: &mut Environment) {
+    env.add_function("max", |call| extrema("max", call.args, true));
+    env.add_function("min", |call| extrema("min", call.args, false));
+    env.add_function("abs", |call| match one_number("abs", call.args)? {
+        Value::Integer(value) => value
+            .checked_abs()
+            .map(Value::Integer)
+            .ok_or_else(|| "abs() integer overflow".to_string().into()),
+        Value::Float(value) => Ok(Value::Float(value.abs())),
+        _ => unreachable!("validated numeric argument"),
+    });
+    env.add_function("ceil", |call| match one_number("ceil", call.args)? {
+        Value::Float(value) => Ok(Value::Float(value.ceil())),
+        _ => bail!("ceil() takes a float as the argument"),
+    });
+    env.add_function("floor", |call| match one_number("floor", call.args)? {
+        Value::Float(value) => Ok(Value::Float(value.floor())),
+        _ => bail!("floor() takes a float as the argument"),
+    });
+    env.add_function("round", |call| match one_number("round", call.args)? {
+        Value::Float(value) => Ok(Value::Float(value.round())),
+        _ => bail!("round() takes a float as the argument"),
+    });
+}


### PR DESCRIPTION
## Summary

- add `max`, `min`, `abs`, `ceil`, `floor`, and `round`
- add `type` and safe `get` lookups
- add `toBase64` and `fromBase64`
- add `toPairs` and `fromPairs`
- make the compatibility harness compare numeric JSON values semantically across serializer formatting differences
- expand the Go-verified corpus from 47 to 68 executable cases

## Why

These functions are part of the pinned Go expr v1.17.8 language surface and account for a substantial portion of the remaining built-in gap.

## Impact

The default environment gains the new functions. Base64 support adds the small `base64` crate dependency. Invalid types and arities return expression errors.

## Stack

- built on the literal-syntax and compatibility-corpus PRs above #80

## Checks

- Go expr v1.17.8 verified all 68 executable corpus cases
- `cargo test --test go_compat`
- `cargo test --all-features` (110 unit tests, 1 compatibility test, 10 doctests)
- `git diff --check`
- clippy reaches only the two pre-existing formatting-borrow warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens the public built-in API and numeric comparison semantics; mitigated by expanded Go-verified compat cases and localized error handling for bad types/arity.
> 
> **Overview**
> Extends the default expression environment with **Go expr–compatible built-ins** and wires them through new `number` and `misc` modules registered from `Environment::new()`.
> 
> **Numeric:** `max`/`min` (variadic, nested arrays), `abs`, `ceil`/`floor`/`round`, `mean`/`median`, with mixed int/float ordering that preserves large integers beyond `f64` precision.
> 
> **Utilities:** `type`, safe `get` on arrays/maps (missing → null), `toBase64`/`fromBase64` (adds `base64` 0.22), and `toPairs`/`fromPairs` for map ↔ pair arrays.
> 
> The Go compatibility corpus grows by **21 cases** (47 → 68) covering these functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54a4da7687b46eb76d95bdf7252aa06926a84f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->