### PR TITLE
feat(lib): add collection utility built-ins

### DIFF
--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -65,6 +65,18 @@ type(ceil(2))	"float"
 max([1, [5, 3]], 4)	5
 mean([1, 2, 3, 4])	2.5
 median([4, 1, 3, 2])	2.5
+join(["a", "b", "c"], "-")	"a-b-c"
+join(["a", "b"])	"ab"
+first([1, 2, 3])	1
+first([])	null
+last([1, 2, 3])	3
+last([])	null
+take([1, 2, 3], 2)	[1,2]
+take([1, 2], 9)	[1,2]
+reverse([1, 2, 3])	[3,2,1]
+uniq([1, 2, 1, 3, 2])	[1,2,3]
+concat([1, 2], [3], [])	[1,2,3]
+flatten([1, [2, [3]], 4])	[1,2,3,4]
 type(nil)	"nil"
 type(42)	"int"
 type(1.5)	"float"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,7 +1,9 @@
 use crate::ast::node::Node;
 use crate::ast::program::Program;
 use crate::context::ContextScope;
-use crate::functions::{array, bitwise, convert, json, misc, number, string, ExprCall, Function};
+use crate::functions::{
+    array, bitwise, collection, convert, json, misc, number, string, ExprCall, Function,
+};
 use crate::parser::compile;
 use crate::{bail, ContextProvider, Result, Value};
 use indexmap::IndexMap;
@@ -73,6 +75,7 @@ impl<'a> Environment<'a> {
         string::add_string_functions(&mut p);
         array::add_array_functions(&mut p);
         bitwise::add_bitwise_functions(&mut p);
+        collection::add_collection_functions(&mut p);
         convert::add_conversion_functions(&mut p);
         json::add_json_functions(&mut p);
         misc::add_misc_functions(&mut p);

--- a/src/functions/collection.rs
+++ b/src/functions/collection.rs
@@ -1,0 +1,131 @@
+use crate::{Environment, Value, bail};
+
+fn one_array(name: &str, mut args: Vec<Value>) -> crate::Result<Vec<Value>> {
+    if args.len() != 1 {
+        bail!("{name}() takes exactly one argument");
+    }
+    match args.pop().expect("length checked") {
+        Value::Array(values) => Ok(values),
+        _ => bail!("{name}() takes an array as the argument"),
+    }
+}
+
+fn flatten(values: Vec<Value>, output: &mut Vec<Value>) {
+    let mut pending = values;
+    pending.reverse();
+    while let Some(value) = pending.pop() {
+        match value {
+            Value::Array(mut values) => {
+                values.reverse();
+                pending.extend(values);
+            }
+            value => output.push(value),
+        }
+    }
+}
+
+/// Add Go expr-compatible collection utility functions.
+pub fn add_collection_functions(env: &mut Environment) {
+    env.add_function("join", |call| {
+        if call.args.is_empty() || call.args.len() > 2 {
+            bail!("join() takes one or two arguments");
+        }
+        let separator = match call.args.get(1) {
+            Some(Value::String(separator)) => separator.as_str(),
+            Some(_) => bail!("join() separator must be a string"),
+            None => "",
+        };
+        let Value::Array(values) = &call.args[0] else {
+            bail!("join() takes an array as the first argument");
+        };
+        let values = values
+            .iter()
+            .map(|value| match value {
+                Value::String(value) => Ok(value.as_str()),
+                _ => bail!("join() array elements must be strings"),
+            })
+            .collect::<crate::Result<Vec<_>>>()?;
+        Ok(Value::from(values.join(separator)))
+    });
+
+    env.add_function("first", |call| {
+        Ok(one_array("first", call.args)?
+            .into_iter()
+            .next()
+            .unwrap_or_default())
+    });
+    env.add_function("last", |call| {
+        Ok(one_array("last", call.args)?
+            .into_iter()
+            .next_back()
+            .unwrap_or_default())
+    });
+    env.add_function("take", |call| {
+        if call.args.len() != 2 {
+            bail!("take() takes exactly two arguments");
+        }
+        let Value::Array(values) = &call.args[0] else {
+            bail!("take() takes an array as the first argument");
+        };
+        let Value::Integer(count) = call.args[1] else {
+            bail!("take() takes an integer as the second argument");
+        };
+        let count = usize::try_from(count).map_err(|_| {
+            crate::Error::ExprError("take() count cannot be negative".to_string())
+        })?;
+        Ok(Value::Array(
+            values.iter().take(count).cloned().collect(),
+        ))
+    });
+    env.add_function("reverse", |call| {
+        let mut values = one_array("reverse", call.args)?;
+        values.reverse();
+        Ok(Value::Array(values))
+    });
+    env.add_function("uniq", |call| {
+        let mut output = Vec::new();
+        for value in one_array("uniq", call.args)? {
+            if !output.contains(&value) {
+                output.push(value);
+            }
+        }
+        Ok(Value::Array(output))
+    });
+    env.add_function("concat", |call| {
+        if call.args.is_empty() {
+            bail!("concat() takes at least one argument");
+        }
+        let mut output = Vec::new();
+        for value in call.args {
+            match value {
+                Value::Array(values) => output.extend(values),
+                _ => bail!("concat() arguments must be arrays"),
+            }
+        }
+        Ok(Value::Array(output))
+    });
+    env.add_function("flatten", |call| {
+        let values = one_array("flatten", call.args)?;
+        let mut output = Vec::new();
+        flatten(values, &mut output);
+        Ok(Value::Array(output))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::flatten;
+    use crate::Value;
+
+    #[test]
+    fn flatten_handles_deeply_nested_arrays_iteratively() {
+        let mut value = Value::Integer(1);
+        for _ in 0..20_000 {
+            value = Value::Array(vec![value]);
+        }
+
+        let mut output = Vec::new();
+        flatten(vec![value], &mut output);
+        assert_eq!(output, vec![Value::Integer(1)]);
+    }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod bitwise;
+pub mod collection;
 pub mod convert;
 pub mod json;
 pub mod misc;


### PR DESCRIPTION
## Summary

- add `join`, including its optional separator
- add `first`, `last`, and bounded `take`
- add `reverse`, stable `uniq`, variadic `concat`, and recursive `flatten`
- add Go-verified compatibility cases for empty and nested collections

## Why

These complete the non-predicate collection utilities exposed by pinned Go expr v1.17.8.

## Impact

The default environment gains eight built-ins. Empty `first`/`last` calls return `nil`, `take` caps at the input length, and collection functions return owned arrays without mutating inputs.

## Stack

- built on the numeric/utility built-ins PR

## Checks

- Go expr v1.17.8 verified all 85 executable corpus cases
- `cargo test --test go_compat`
- `cargo test --all-features` (110 unit tests, 1 compatibility test, 10 doctests)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive builtins with validation and non-mutating behavior; no changes to auth, I/O, or core eval semantics beyond new function registration.
> 
> **Overview**
> Adds **eight Go expr–compatible collection builtins** to the default environment via a new `collection` module: `join` (optional separator), `first`/`last` (empty arrays → `nil`), `take`, `reverse`, stable `uniq`, variadic `concat`, and iterative `flatten` (with a deep-nesting unit test to avoid stack overflow).
> 
> `Environment::new` now registers `collection::add_collection_functions`, and **compat/cases.tsv** gains executable cases for empty inputs, bounded `take`, and nested `flatten`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f0b0b16038405b36fbfac41a2ebb9498c3e0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->