### PR TITLE
feat(lib): add aggregate predicate built-ins

### DIFF
--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -84,6 +84,9 @@ sum([1, 2.5, 3])	6.5
 sum([1, 2, 3], {# * 2})	12
 reduce([1, 2, 3], #acc + #)	6
 reduce([1, 2, 3], #acc + #, 10)	16
+reduce([1, 2, 3], {let doubled = # * 2; #acc + doubled}, 10)	22
+[1, 2, 3] | reduce(#acc + #, 10)	16
+[1, 2, 3] | reduce({#acc + #}, 10)	16
 type(nil)	"nil"
 type(42)	"int"
 type(1.5)	"float"

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -77,6 +77,13 @@ reverse([1, 2, 3])	[3,2,1]
 uniq([1, 2, 1, 3, 2])	[1,2,3]
 concat([1, 2], [3], [])	[1,2,3]
 flatten([1, [2, [3]], 4])	[1,2,3,4]
+count([true, false, true])	2
+count([1, 2, 3], {# > 1})	2
+sum([1, 2, 3])	6
+sum([1, 2.5, 3])	6.5
+sum([1, 2, 3], {# * 2})	12
+reduce([1, 2, 3], #acc + #)	6
+reduce([1, 2, 3], #acc + #, 10)	16
 type(nil)	"nil"
 type(42)	"int"
 type(1.5)	"float"

--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -133,14 +133,21 @@ impl From<Pair<'_, Rule>> for Node {
                 // Uses >= 1 (not >= 2) so pipe syntax works: `arr | filter(# > 2)`.
                 if predicate.is_none()
                     && ident == "reduce"
-                    && args.len() >= 3
-                    && args[1].contains_hash_ident()
                 {
-                    let reducer = args.remove(1);
-                    predicate = Some(Box::new(Program {
-                        lines: Vec::new(),
-                        expr: reducer,
-                    }));
+                    let reducer_index = if args.len() >= 2 && args[1].contains_hash_ident() {
+                        Some(1)
+                    } else if !args.is_empty() && args[0].contains_hash_ident() {
+                        Some(0)
+                    } else {
+                        None
+                    };
+                    if let Some(index) = reducer_index {
+                        let reducer = args.remove(index);
+                        predicate = Some(Box::new(Program {
+                            lines: Vec::new(),
+                            expr: reducer,
+                        }));
+                    }
                 } else if predicate.is_none()
                     && !args.is_empty()
                     && Self::accepts_predicate(&ident)

--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -35,7 +35,7 @@ impl Node {
     /// Check if this node or any of its children reference the `#` variable
     pub(crate) fn contains_hash_ident(&self) -> bool {
         match self {
-            Node::Ident(id) => id == "#",
+            Node::Ident(id) => id.starts_with('#'),
             Node::Operation { left, right, .. } => {
                 left.contains_hash_ident() || right.contains_hash_ident()
             }
@@ -132,6 +132,16 @@ impl From<Pair<'_, Rule>> for Node {
                 // nested calls like `indexOf("abc", #)` inside braced predicates.
                 // Uses >= 1 (not >= 2) so pipe syntax works: `arr | filter(# > 2)`.
                 if predicate.is_none()
+                    && ident == "reduce"
+                    && args.len() >= 3
+                    && args[1].contains_hash_ident()
+                {
+                    let reducer = args.remove(1);
+                    predicate = Some(Box::new(Program {
+                        lines: Vec::new(),
+                        expr: reducer,
+                    }));
+                } else if predicate.is_none()
                     && !args.is_empty()
                     && Self::accepts_predicate(&ident)
                     && args.last().unwrap().contains_hash_ident()

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -116,10 +116,8 @@ impl Environment<'_> {
                     predicate,
                 } = func.as_ref()
                 {
-                    let args = args
-                        .iter()
-                        .map(|arg| self.eval_expr(ctx, arg))
-                        .chain(once(Ok(value)))
+                    let args = once(Ok(value))
+                        .chain(args.iter().map(|arg| self.eval_expr(ctx, arg)))
                         .collect::<Result<Vec<Value>>>()?;
                     self.eval_func(ctx, ident, args, predicate.as_deref())?
                 } else {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -133,7 +133,7 @@ impl<'a> Environment<'a> {
 
     pub(crate) fn run_with_two_bindings(
         &self,
-        program: Program,
+        program: &Program,
         ctx: &dyn ContextProvider,
         first: (&str, Value),
         second: (&str, Value),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -131,6 +131,19 @@ impl<'a> Environment<'a> {
         self.run(program, &scope)
     }
 
+    pub(crate) fn run_with_two_bindings(
+        &self,
+        program: Program,
+        ctx: &dyn ContextProvider,
+        first: (&str, Value),
+        second: (&str, Value),
+    ) -> Result<Value> {
+        let mut scope = ContextScope::new(ctx);
+        scope.insert(first.0, first.1);
+        scope.insert(second.0, second.1);
+        self.run(program, &scope)
+    }
+
     /// Compile and run an expr program in one step
     ///
     /// Example:

--- a/src/expr.pest
+++ b/src/expr.pest
@@ -7,9 +7,10 @@ prefix  = _{ negation_op | sign_op }
 infix   = _{ exponent_op | multiplication_op | addition_op | comparison_op | equal_op | and_op | or_op | not_in_op | string_op }
 postfix = _{ ternary | range_start_op | range_end_op | opt_membership_op | opt_index_op | membership_op | index_op | default_op | pipe }
 
-func              =  { ident ~ "(" ~ (expr ~ ("," ~ expr)*)? ~ (","? ~ predicate)? ~ ")" }
+func              =  { ident ~ "(" ~ (func_arg ~ ("," ~ func_arg)*)? ~ ")" }
+func_arg          = _{ predicate | expr }
 pipe              =  { "|" ~ func }
-predicate         =  { "." ~ ident | ("{"? ~ (program | expr) ~ "}"?) }
+predicate         =  { "." ~ ident | "{" ~ program ~ "}" }
 term              = _{ func | range | value | ident | array | map | "(" ~ expr ~ ")" }
 ternary           =  { "?" ~ expr ~ ":" ~ expr }
 membership_op     =  { "." ~ ident }

--- a/src/expr.pest
+++ b/src/expr.pest
@@ -55,7 +55,7 @@ decimal          = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ | "." ~ ASCII_DIGIT+ }
 
 not_in_op        = @{ "not" ~ WHITESPACE+ ~ "in" }
 
-ident         = @{ "#" | (("$" | ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*) }
+ident         = @{ "#" ~ (ASCII_ALPHANUMERIC | "_")* | (("$" | ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*) }
 char_single   =  {
     !("'" | "\\") ~ ANY
   | "\\" ~ ("'" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -24,7 +24,7 @@ pub fn add_array_functions(env: &mut Environment) {
             for value in values {
                 match c
                     .env
-                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                    .run_with_binding(predicate, c.ctx, "#", value.clone())?
                 {
                     Value::Bool(true) => count += 1,
                     Value::Bool(false) => {}
@@ -54,7 +54,7 @@ pub fn add_array_functions(env: &mut Environment) {
         for value in values {
             let value = if let Some(predicate) = &c.predicate {
                 c.env
-                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                    .run_with_binding(predicate, c.ctx, "#", value.clone())?
             } else {
                 value.clone()
             };
@@ -77,12 +77,12 @@ pub fn add_array_functions(env: &mut Environment) {
             Some(initial) => (initial.clone(), 0),
             None => match values.first() {
                 Some(first) => (first.clone(), 1),
-                None => return Ok(Value::Nil),
+                None => bail!("reduce() of an empty array requires an initial value"),
             },
         };
         for value in &values[start..] {
             accumulator = c.env.run_with_two_bindings(
-                predicate.clone(),
+                predicate,
                 c.ctx,
                 ("#", value.clone()),
                 ("#acc", accumulator),

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -1,7 +1,96 @@
 use crate::{bail, Environment, Value};
 use indexmap::IndexMap;
 
+fn add_sum(total: Value, value: Value) -> crate::Result<Value> {
+    match (total, value) {
+        (Value::Integer(total), Value::Integer(value)) => Ok(Value::Integer(total + value)),
+        (Value::Integer(total), Value::Float(value)) => Ok(Value::Float(total as f64 + value)),
+        (Value::Float(total), Value::Integer(value)) => Ok(Value::Float(total + value as f64)),
+        (Value::Float(total), Value::Float(value)) => Ok(Value::Float(total + value)),
+        _ => bail!("sum() values must be numbers"),
+    }
+}
+
 pub fn add_array_functions(env: &mut Environment) {
+    env.add_function("count", |c| {
+        if c.args.len() != 1 {
+            bail!("count() takes exactly one array argument");
+        }
+        let Value::Array(values) = &c.args[0] else {
+            bail!("count() takes an array as the first argument");
+        };
+        let mut count = 0;
+        if let Some(predicate) = c.predicate {
+            for value in values {
+                match c
+                    .env
+                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+                {
+                    Value::Bool(true) => count += 1,
+                    Value::Bool(false) => {}
+                    _ => bail!("count() predicate must return a boolean"),
+                }
+            }
+        } else {
+            for value in values {
+                match value {
+                    Value::Bool(true) => count += 1,
+                    Value::Bool(false) => {}
+                    _ => bail!("count() without a predicate requires booleans"),
+                }
+            }
+        }
+        Ok(Value::Integer(count))
+    });
+
+    env.add_function("sum", |c| {
+        if c.args.len() != 1 {
+            bail!("sum() takes exactly one array argument");
+        }
+        let Value::Array(values) = &c.args[0] else {
+            bail!("sum() takes an array as the first argument");
+        };
+        let mut total = Value::Integer(0);
+        for value in values {
+            let value = if let Some(predicate) = &c.predicate {
+                c.env
+                    .run_with_binding(predicate.clone(), c.ctx, "#", value.clone())?
+            } else {
+                value.clone()
+            };
+            total = add_sum(total, value)?;
+        }
+        Ok(total)
+    });
+
+    env.add_function("reduce", |c| {
+        if c.args.is_empty() || c.args.len() > 2 {
+            bail!("reduce() takes an array and optional initial value");
+        }
+        let Value::Array(values) = &c.args[0] else {
+            bail!("reduce() takes an array as the first argument");
+        };
+        let Some(predicate) = c.predicate else {
+            bail!("reduce() requires a predicate");
+        };
+        let (mut accumulator, start) = match c.args.get(1) {
+            Some(initial) => (initial.clone(), 0),
+            None => match values.first() {
+                Some(first) => (first.clone(), 1),
+                None => return Ok(Value::Nil),
+            },
+        };
+        for value in &values[start..] {
+            accumulator = c.env.run_with_two_bindings(
+                predicate.clone(),
+                c.ctx,
+                ("#", value.clone()),
+                ("#acc", accumulator),
+            )?;
+        }
+        Ok(accumulator)
+    });
+
     env.add_function("all", |c| {
         if c.args.len() != 1 {
             bail!("all() takes exactly one argument and a predicate");

--- a/src/test.rs
+++ b/src/test.rs
@@ -144,6 +144,12 @@ fn context_is_materialized_only_for_env() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn empty_reduce_without_initial_value_errors() {
+    let context = Context::default();
+    assert!(eval("reduce([], #acc + #)", &context).is_err());
+}
+
 test!(order_of_ops, "1 + 2 * 3 + 1", "8");
 test!(is_true, "true", "true");
 test!(not_1, "!true", "false");


### PR DESCRIPTION
## Summary

- add `count` with predicate and boolean-array forms
- add integer/float `sum` with optional projection predicates
- add `reduce` with optional initial values
- recognize `#acc` as the reducer accumulator binding
- preserve borrowed context overlays while evaluating aggregate predicates

## Why

`count`, `sum`, and `reduce` are the remaining predicate-driven collection built-ins in pinned Go expr v1.17.8.

## Impact

The grammar now accepts predicate identifiers such as `#acc`. Existing `#` behavior is unchanged. Aggregate predicates remain short-lived borrowed scopes and do not clone the input context.

## Stack

- built on the collection utility built-ins PR

## Checks

- Go expr v1.17.8 verified all 92 executable corpus cases
- `cargo test --test go_compat`
- `cargo test --all-features` (110 unit tests, 1 compatibility test, 10 doctests)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches expression grammar, pipe argument order, and predicate promotion; behavior is covered by compat corpus and tests but affects parsing/eval broadly.
> 
> **Overview**
> Adds **`count`**, **`sum`**, and **`reduce`** as collection aggregates aligned with Go expr v1.17.8: boolean-only `count` without a predicate, predicate forms for counting and summing (including numeric promotion for mixed int/float `sum`), and `reduce` with optional initial value and **`#acc`** / **`#`** bindings via new **`run_with_two_bindings`**.
> 
> Parser and AST changes support this: identifiers can be **`#`-prefixed** (e.g. `#acc`), function args may be explicit **`predicate`** blocks, **`reduce`** gets special promotion of the reducer expression into the predicate slot, and **pipe** passes the left-hand value as the **first** argument so forms like `[1,2,3] | reduce(#acc + #, 10)` work.
> 
> Compatibility cases and a unit test cover aggregates and empty **`reduce`** without an initial value (error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e04393a5f8eb7f419272471dd558b9aedc985c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->