### PR TITLE
chore: harden v2 release checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           shared-key: rust-${{ matrix.target }}
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
-      - run: cargo build
-      - run: cargo test
+      - run: cargo build --all-features
+      - run: cargo test --all-features
       - run: mise lint
+      - run: cargo package
+      - run: rustup toolchain install 1.85.0 --profile minimal
+      - run: cargo +1.85.0 test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "expr-lang"
 version = "1.1.1"
 edition = "2024"
+rust-version = "1.85"
 authors = ["@jdx"]
 license = "MIT"
 documentation = "https://docs.rs/expr-lang"
@@ -9,11 +10,16 @@ homepage = "https://github.com/jdx/expr.rs"
 repository = "https://github.com/jdx/expr.rs"
 description = "Implementation of expr language in Rust"
 include = [
+    "/CHANGELOG.md",
+    "/LICENSE",
+    "/README.md",
     "/compat/cases.tsv",
     "/compat/errors.tsv",
+    "/examples/**/*.rs",
     "/MIGRATION.md",
     "/src/**/*.pest",
     "/src/**/*.rs",
+    "/tests/**/*.rs",
 ]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ other Rust applications. The next release will be v2.
 expression-language parity. Go-specific reflection, static type checking,
 optimization, and bytecode execution are outside that compatibility target.
 
+The v2 compatibility profile covers nil, booleans, integers, floats, strings,
+arrays, and string-keyed maps. Bytes, date/time values, non-string map keys,
+multiline `if`/`else`, and scientific-notation literals are not yet supported.
+
 Evaluation is currently tree-walking. Bytecode compilation is not planned for
 v2; correctness, compatibility, and a small embeddable API take priority. A
 bytecode backend could be considered later if real-world profiling shows that
@@ -51,7 +55,7 @@ fn main() {
 
 ```toml
 [dependencies]
-expr-lang = { version = "1", features = ["serde"] }
+expr-lang = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 ```
 
@@ -83,7 +87,7 @@ fn main() {
 
 ```toml
 [dependencies]
-expr-lang = { version = "1", features = ["serde"] }
+expr-lang = { version = "2", features = ["serde"] }
 serde_json = "1.0"
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -10,14 +10,20 @@ cargo.binstall_native = true
 
 [tasks.lint]
 run = [
-  "cargo clippy",
+  "cargo clippy --all-targets --all-features -- -D warnings",
   "pestfmt src/expr.pest",
 ]
 
 [tasks.test]
 alias = "t"
 depends = ["lint"]
-run = "cargo test"
+run = "cargo test --all-features"
+
+[tasks."release:check"]
+run = [
+  "cargo test --all-features",
+  "cargo package",
+]
 
 [tasks.perf]
 run = [

--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -105,7 +105,7 @@ impl From<Pairs<'_, Rule>> for Node {
 
 impl From<Pair<'_, Rule>> for Node {
     fn from(pair: Pair<Rule>) -> Self {
-        trace!("{:?} = {}", &pair.as_rule(), pair.as_str());
+        trace!("{:?} = {}", pair.as_rule(), pair.as_str());
         match pair.as_rule() {
             Rule::expr => pair.into_inner().into(),
             Rule::value => Node::Value(pair.into_inner().into()),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -165,7 +165,7 @@ impl<'a> Environment<'a> {
             Node::Ident(id) => {
                 if id == "$env" {
                     Value::Map(ctx.environment().0)
-                } else if let Some(value) = ctx.get(&id) {
+                } else if let Some(value) = ctx.get(id) {
                     value.clone()
                 } else if let Some(item) = ctx
                     .get("#")
@@ -183,7 +183,7 @@ impl<'a> Environment<'a> {
                 predicate,
             } => {
                 let args = args
-                    .into_iter()
+                    .iter()
                     .map(|e| self.eval_expr(ctx, e))
                     .collect::<Result<_>>()?;
                 self.eval_func(ctx, ident, args, predicate.as_deref())?

--- a/src/expr.pest
+++ b/src/expr.pest
@@ -53,7 +53,7 @@ bool             =  { "true" | "false" }
 nil              =  { "nil" }
 decimal          = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ | "." ~ ASCII_DIGIT+ }
 
-not_in_op        = @{ "not" ~ WHITESPACE+ ~ "in" }
+not_in_op = @{ "not" ~ WHITESPACE+ ~ "in" }
 
 ident         = @{ "#" ~ (ASCII_ALPHANUMERIC | "_")* | (("$" | ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*) }
 char_single   =  {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -297,8 +297,8 @@ mod tests {
         let integer_val = value!(42);
         assert_eq!(integer_val, Value::Integer(42));
 
-        let float_val = value!(3.14);
-        assert_eq!(float_val, Value::Float(3.14));
+        let float_val = value!(3.125);
+        assert_eq!(float_val, Value::Float(3.125));
 
         let negative_val = value!(-10.5);
         assert_eq!(negative_val, Value::Float(-10.5));
@@ -362,7 +362,7 @@ mod tests {
             "boolean": true,
             "string": "hello",
             "nil": nil,
-            "number": 3.14,
+            "number": 3.125,
             "array": [1, 2, 3],
             "nested_map": {
                 "inner_key": "inner_value",
@@ -372,7 +372,7 @@ mod tests {
             ("boolean", Value::Bool(true)),
             ("string", Value::String("hello".to_string())),
             ("nil", Value::Nil),
-            ("number", Value::Float(3.14)),
+            ("number", Value::Float(3.125)),
             ("array", Value::from(vec![
                 Value::Integer(1),
                 Value::Integer(2),
@@ -390,7 +390,7 @@ mod tests {
         let bool_var = true;
         let string_var = "hello".to_string();
         let int_var = 42;
-        let float_var = 3.14;
+        let float_var = 3.125;
         let nil_var = Value::Nil;
         let array_var = vec![1, 2, 3];
         let map_var: IndexMap<String, Value> = IndexMap::from([
@@ -410,7 +410,7 @@ mod tests {
             ("bool", Value::from(true)),
             ("string", Value::from("hello")),
             ("int", Value::from(42)),
-            ("float", Value::from(3.14)),
+            ("float", Value::from(3.125)),
             ("nil", Value::Nil),
             ("array", Value::from(vec![
                 Value::from(1),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -479,7 +479,7 @@ mod tests {
                 "j": "k"
             }]
         }"#;
-        let val: serde_json::value::Value = serde_json::from_str(&raw).unwrap();
+        let val: serde_json::value::Value = serde_json::from_str(raw).unwrap();
         serde_json::to_string_pretty(&val).unwrap()
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -202,7 +202,7 @@ impl From<Pairs<'_, Rule>> for Value {
 
 impl From<Pair<'_, Rule>> for Value {
     fn from(pair: Pair<Rule>) -> Self {
-        trace!("{:?} = {}", &pair.as_rule(), pair.as_str());
+        trace!("{:?} = {}", pair.as_rule(), pair.as_str());
         match pair.as_rule() {
             Rule::value => pair.into_inner().into(),
             Rule::nil => Value::Nil,


### PR DESCRIPTION
## Summary

- test all features in CI and enforce warning-free clippy across all targets
- package and verify the crate in CI
- test the declared Rust 1.85 MSRV
- include the license, README, changelog, examples, tests, and negative compatibility corpus in the crate tarball
- update README dependency examples for v2
- document the exact v2 compatibility profile and remaining exclusions
- add a local `mise run release:check` task

## Why

The v2 stack changes public APIs and expands the language surface, so the release gate should cover serde, the published artifact, the supported compiler floor, and strict linting rather than only default-feature tests.

## Impact

The crate now declares Rust 1.85 as its minimum supported version. Runtime behavior is unchanged; this PR tightens CI, packaging, and release documentation.

## Stack

- built on #91
- merge the compatibility-correctness PR first

## Checks

- `cargo test --all-features` (115 unit tests, 2 compatibility tests, 10 doctests)
- `cargo +1.85.0 test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo package --allow-dirty` (39 files, package verification passed)
- confirmed `LICENSE`, docs, examples, tests, and both compatibility corpora are packaged
- `git diff --check`

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI, packaging, and documentation; runtime behavior is unchanged aside from trivial lint-only code edits.
> 
> **Overview**
> Tightens the **v2 release gate** so CI and local tasks exercise the full feature set, enforce warning-free Clippy, verify the published crate, and run tests on the declared compiler floor.
> 
> **CI** now runs `cargo build`/`test` with `--all-features`, `cargo package`, and `cargo +1.85.0 test --all-features` after installing Rust 1.85. **`Cargo.toml`** sets `rust-version = "1.85"` and expands the `include` list so LICENSE, README, changelog, examples, tests, and compatibility corpora ship in the tarball.
> 
> **Developer workflow**: `mise` lint uses `clippy --all-targets --all-features -D warnings`; default tests use `--all-features`; new **`mise run release:check`** runs tests plus `cargo package`.
> 
> **Docs**: README documents the v2 compatibility profile (supported types vs known gaps) and updates serde examples to **`expr-lang` v2**.
> 
> Minor **Clippy-driven** source tweaks only (e.g. `ctx.get(id)`, `args.iter()`, trace formatting, test literals `3.125` instead of `3.14`); no intended evaluation semantics change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb1e49cdadd72fd358d4f0a13b596deef76b5e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->