### PR TITLE
feat(lib)!: add non-string map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ expression-language parity. Go-specific reflection, static type checking,
 optimization, and bytecode execution are outside that compatibility target.
 
 The v2 compatibility profile covers nil, booleans, integers, floats, strings,
-bytes, arrays, string-keyed maps, dates, durations, and timezones. Non-string
-map keys are not yet supported.
+bytes, arrays, maps with arbitrary keys, dates, durations, and timezones.
 
 Evaluation is currently tree-walking. Bytecode compilation is not planned for
 v2; correctness, compatibility, and a small embeddable API take priority. A

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -164,3 +164,12 @@ date("2023-08-04").In(timezone("Europe/Zurich")).Format("MST -0700 Z0700")	"CEST
 date("4 8 2023 3:6:7 +0230", "2 1 2006 3:4:5 -0700")	"2023-08-04T03:06:07+02:30"
 date("4 Aug 2023 UTC", "2 Jan 2006 MST")	"2023-08-04T00:00:00Z"
 duration("1h") < duration("2h")	true
+get(fromPairs([[1, "one"], [2, "two"]]), 2)	"two"
+fromPairs([[1, "one"]])[1]	"one"
+1 in fromPairs([[1, "one"]])	true
+keys(fromPairs([[1, "one"]]))	[1]
+values(fromPairs([[1, "one"]]))	["one"]
+len(fromPairs([[1, "one"]]))	1
+string(fromPairs([[10, "ten"], [2, "two"], [1, "one"]]))	"map[1:one 2:two 10:ten]"
+string(fromPairs([[true, "yes"], [false, "no"]]))	"map[false:no true:yes]"
+string(fromPairs([[2.5, "b"], [1.5, "a"]]))	"map[1.5:a 2.5:b]"

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,5 +1,5 @@
 use crate::ast::node::Node;
-use crate::Value::{Array, Bool, DateTime, Duration, Float, Integer, Map, Month, String, Weekday};
+use crate::Value::{Array, Bool, DateTime, Duration, Float, Integer, KeyedMap, Map, Month, String, Weekday};
 use crate::{bail, Result, Rule};
 use crate::{ContextProvider, Environment, Value};
 use log::trace;
@@ -63,7 +63,7 @@ impl From<Pair<'_, Rule>> for Operator {
     }
 }
 
-fn values_equal(left: &Value, right: &Value) -> bool {
+pub(crate) fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Integer(left), Float(right)) => *left as f64 == *right,
         (Float(left), Integer(right)) => *left == *right as f64,
@@ -80,6 +80,15 @@ fn values_equal(left: &Value, right: &Value) -> bool {
                     right
                         .get(key)
                         .is_some_and(|right| values_equal(left, right))
+                })
+        }
+        (KeyedMap(left), KeyedMap(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(left_key, left_value)| {
+                    right.iter().any(|(right_key, right_value)| {
+                        values_equal(left_key, right_key)
+                            && values_equal(left_value, right_value)
+                    })
                 })
         }
         _ => left == right,
@@ -241,6 +250,10 @@ impl Environment<'_> {
             Operator::And | Operator::Or => unreachable!("handled before evaluating right operand"),
             Operator::In => match (left, right) {
                 (String(left), Map(right)) => right.contains_key(&left).into(),
+                (left, KeyedMap(right)) => right
+                    .iter()
+                    .any(|(key, _)| values_equal(&left, key))
+                    .into(),
                 (left, Array(right)) => right
                     .iter()
                     .any(|right| values_equal(&left, right))
@@ -249,7 +262,11 @@ impl Environment<'_> {
             },
             Operator::NotIn => match (left, right) {
                 (String(left), Map(right)) => (!right.contains_key(&left)).into(),
-                (left, Array(right)) => (!right.contains(&left)).into(),
+                (left, KeyedMap(right)) => (!right
+                    .iter()
+                    .any(|(key, _)| values_equal(&left, key)))
+                    .into(),
+                (left, Array(right)) => (!right.iter().any(|right| values_equal(&left, right))).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::Contains => match (left, right) {

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -86,28 +86,31 @@ impl Environment<'_> {
     ) -> Result<Value> {
         let value = self.eval_expr(ctx, node)?;
         let result = match operator {
-            PostfixOperator::Index { idx, optional } => match self.eval_index_key(ctx, idx)? {
-                Value::Integer(idx) => match value {
-                    Value::Array(arr) => {
-                        let idx = i64_to_idx(idx, arr.len());
+            PostfixOperator::Index { idx, optional } => {
+                let key = self.eval_index_key(ctx, idx)?;
+                match (&key, value) {
+                    (Value::Integer(idx), Value::Array(arr)) => {
+                        let idx = i64_to_idx(*idx, arr.len());
                         arr.get(idx).cloned().unwrap_or(Value::Nil)
                     }
-                    Value::Bytes(bytes) => {
-                        let idx = i64_to_idx(idx, bytes.len());
+                    (Value::Integer(idx), Value::Bytes(bytes)) => {
+                        let idx = i64_to_idx(*idx, bytes.len());
                         bytes
                             .get(idx)
                             .map(|byte| Value::Integer((*byte).into()))
                             .unwrap_or(Value::Nil)
                     }
-                    _ if *optional => Value::Nil,
-                    _ => bail!("Invalid operand for operator []"),
-                },
-                Value::String(key) => match value {
-                    Value::Map(map) => map.get(&key).cloned().unwrap_or(Value::Nil),
-                    _ if *optional => Value::Nil,
-                    _ => bail!("Invalid operand for operator []"),
-                },
-                v => bail!("Invalid operand for operator []: {v:?}"),
+                    (Value::String(key), Value::Map(map)) => {
+                        map.get(key).cloned().unwrap_or(Value::Nil)
+                    }
+                    (key, Value::KeyedMap(map)) => map
+                        .into_iter()
+                        .find(|(candidate, _)| crate::ast::operator::values_equal(key, candidate))
+                        .map(|(_, value)| value)
+                        .unwrap_or(Value::Nil),
+                    (_, _) if *optional => Value::Nil,
+                    _ => bail!("Invalid operand for operator []: {key:?}"),
+                }
             },
             PostfixOperator::Range(start, end) => match value {
                 Value::Array(arr) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{bail, Result, Value};
+use crate::{bail, Error, Result, Value};
 use indexmap::IndexMap;
 use std::fmt::Display;
 
@@ -99,6 +99,9 @@ impl TryFrom<Value> for Context {
     fn try_from(value: Value) -> Result<Self> {
         match value {
             Value::Map(values) => Ok(Self(values)),
+            Value::KeyedMap(_) => Err(Error::ExprError(
+                "context keys must be strings".to_string(),
+            )),
             value => bail!("context must be a map, got {value:?}"),
         }
     }

--- a/src/functions/convert.rs
+++ b/src/functions/convert.rs
@@ -104,6 +104,38 @@ fn expr_string(value: &Value) -> String {
             .collect::<Vec<_>>()
             .join(" ")
         ),
+        Value::KeyedMap(values) => format!(
+            "map[{}]",
+            {
+                let mut values = values.iter().collect::<Vec<_>>();
+                values.sort_by(|(left, _), (right, _)| compare_map_keys(left, right));
+                values
+            }
+                .into_iter()
+                .map(|(key, value)| format!("{}:{}", expr_string(key), expr_string(value)))
+                .collect::<Vec<_>>()
+                .join(" ")
+        ),
+    }
+}
+
+fn compare_map_keys(left: &Value, right: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (left, right) {
+        (Value::Nil, Value::Nil) => Ordering::Equal,
+        (Value::Bool(left), Value::Bool(right)) => left.cmp(right),
+        (Value::Integer(left), Value::Integer(right)) => left.cmp(right),
+        (Value::Float(left), Value::Float(right)) => match (left.is_nan(), right.is_nan()) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => left.partial_cmp(right).unwrap_or(Ordering::Equal),
+        },
+        (Value::String(left), Value::String(right)) => left.cmp(right),
+        (Value::Duration(left), Value::Duration(right)) => left.cmp(right),
+        (Value::Month(left), Value::Month(right)) | (Value::Weekday(left), Value::Weekday(right)) => left.cmp(right),
+        (Value::DateTime(left), Value::DateTime(right)) => left.partial_cmp(right).unwrap_or(Ordering::Equal),
+        (Value::Timezone(left), Value::Timezone(right)) => left.name().cmp(right.name()),
+        _ => expr_string(left).cmp(&expr_string(right)),
     }
 }
 

--- a/src/functions/json.rs
+++ b/src/functions/json.rs
@@ -1,6 +1,6 @@
 use serde_json;
 
-use crate::{bail, Environment, Value};
+use crate::{bail, Environment, Result, Value};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 
@@ -29,8 +29,8 @@ fn json_to_value(json: serde_json::Value) -> Value {
 }
 
 /// Convert an expr::Value to a serde_json::Value
-fn value_to_json(value: &Value) -> serde_json::Value {
-    match value {
+fn value_to_json(value: &Value) -> Result<serde_json::Value> {
+    Ok(match value {
         Value::Nil => serde_json::Value::Null,
         Value::Bool(b) => serde_json::Value::Bool(*b),
         Value::Integer(n) => serde_json::Value::Number((*n).into()),
@@ -49,15 +49,29 @@ fn value_to_json(value: &Value) -> serde_json::Value {
         Value::Month(value) | Value::Weekday(value) => {
             serde_json::Value::Number((*value).into())
         }
-        Value::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(value_to_json).collect())
-        }
+        Value::Array(arr) => serde_json::Value::Array(
+            arr.iter().map(value_to_json).collect::<Result<Vec<_>>>()?
+        ),
         Value::Map(m) => {
             serde_json::Value::Object(
-                m.iter().map(|(k, v)| (k.clone(), value_to_json(v))).collect()
+                m.iter()
+                    .map(|(k, v)| Ok((k.clone(), value_to_json(v)?)))
+                    .collect::<Result<_>>()?
             )
         }
-    }
+        Value::KeyedMap(m) => serde_json::Value::Object(
+            m.iter()
+                .map(|(key, value)| {
+                    let key = match key {
+                        Value::String(key) => key.clone(),
+                        Value::Integer(key) => key.to_string(),
+                        _ => bail!("toJSON() map keys must be strings or integers"),
+                    };
+                    Ok((key, value_to_json(value)?))
+                })
+                .collect::<Result<_>>()?
+        ),
+    })
 }
 
 pub fn add_json_functions(env: &mut Environment) {
@@ -83,7 +97,7 @@ pub fn add_json_functions(env: &mut Environment) {
         if c.args.len() != 1 {
             bail!("toJSON() takes exactly one argument");
         }
-        let json = value_to_json(&c.args[0]);
+        let json = value_to_json(&c.args[0])?;
         match serde_json::to_string(&json) {
             Ok(s) => Ok(Value::String(s)),
             Err(e) => bail!("toJSON() failed to serialize: {}", e),
@@ -96,10 +110,14 @@ pub fn add_json_functions(env: &mut Environment) {
         if c.args.len() != 1 {
             bail!("keys() takes exactly one argument");
         }
-        if let Value::Map(m) = &c.args[0] {
-            Ok(Value::Array(m.keys().map(|k| Value::String(k.clone())).collect()))
-        } else {
-            bail!("keys() takes a map as the argument");
+        match &c.args[0] {
+            Value::Map(m) => Ok(Value::Array(
+                m.keys().map(|k| Value::String(k.clone())).collect()
+            )),
+            Value::KeyedMap(m) => Ok(Value::Array(
+                m.iter().map(|(key, _)| key.clone()).collect()
+            )),
+            _ => bail!("keys() takes a map as the argument"),
         }
     });
 
@@ -109,10 +127,12 @@ pub fn add_json_functions(env: &mut Environment) {
         if c.args.len() != 1 {
             bail!("values() takes exactly one argument");
         }
-        if let Value::Map(m) = &c.args[0] {
-            Ok(Value::Array(m.values().cloned().collect()))
-        } else {
-            bail!("values() takes a map as the argument");
+        match &c.args[0] {
+            Value::Map(m) => Ok(Value::Array(m.values().cloned().collect())),
+            Value::KeyedMap(m) => Ok(Value::Array(
+                m.iter().map(|(_, value)| value.clone()).collect()
+            )),
+            _ => bail!("values() takes a map as the argument"),
         }
     });
 
@@ -127,6 +147,7 @@ pub fn add_json_functions(env: &mut Environment) {
             Value::String(s) => Ok(Value::Integer(s.len() as i64)),
             Value::Bytes(bytes) => Ok(Value::Integer(bytes.len() as i64)),
             Value::Map(m) => Ok(Value::Integer(m.len() as i64)),
+            Value::KeyedMap(m) => Ok(Value::Integer(m.len() as i64)),
             _ => bail!("len() takes an array, string, or map as the argument"),
         }
     });

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -27,6 +27,7 @@ pub fn add_misc_functions(env: &mut Environment) {
             Value::Weekday(_) => "time.Weekday",
             Value::Array(_) => "array",
             Value::Map(_) => "map",
+            Value::KeyedMap(_) => "map",
         };
         Ok(Value::from(name))
     });
@@ -65,7 +66,12 @@ pub fn add_misc_functions(env: &mut Environment) {
             (Value::Map(values), Value::String(key)) => {
                 Ok(values.get(key).cloned().unwrap_or_default())
             }
-            _ => bail!("get() takes an array or bytes and integer, or a map and string"),
+            (Value::KeyedMap(values), key) => Ok(values
+                .iter()
+                .find(|(candidate, _)| crate::ast::operator::values_equal(candidate, key))
+                .map(|(_, value)| value.clone())
+                .unwrap_or_default()),
+            _ => bail!("get() takes an array or bytes and integer, or a map and key"),
         }
     });
 
@@ -94,24 +100,42 @@ pub fn add_misc_functions(env: &mut Environment) {
                 .map(|(key, value)| Value::Array(vec![Value::from(key), value]))
                 .collect(),
         )),
+        Value::KeyedMap(values) => Ok(Value::Array(
+            values
+                .into_iter()
+                .map(|(key, value)| Value::Array(vec![key, value]))
+                .collect(),
+        )),
         _ => bail!("toPairs() takes a map as the argument"),
     });
     env.add_function("fromPairs", |call| match one_argument("fromPairs", call.args)? {
         Value::Array(pairs) => {
-            let mut values = IndexMap::new();
+            let mut values = Vec::new();
             for pair in pairs {
                 match pair {
                     Value::Array(pair) if pair.len() == 2 => {
                         let mut pair = pair.into_iter();
-                        let Value::String(key) = pair.next().expect("length checked") else {
-                            bail!("fromPairs() pair keys must be strings");
-                        };
-                        values.insert(key, pair.next().expect("length checked"));
+                        let key = pair.next().expect("length checked");
+                        let value = pair.next().expect("length checked");
+                        if let Some((_, existing)) = values.iter_mut().find(|(candidate, _)| {
+                            crate::ast::operator::values_equal(candidate, &key)
+                        }) {
+                            *existing = value;
+                        } else {
+                            values.push((key, value));
+                        }
                     }
                     _ => bail!("fromPairs() expects an array of two-element arrays"),
                 }
             }
-            Ok(Value::Map(values))
+            if values.iter().all(|(key, _)| matches!(key, Value::String(_))) {
+                Ok(Value::Map(values.into_iter().map(|(key, value)| {
+                    let Value::String(key) = key else { unreachable!("checked") };
+                    (key, value)
+                }).collect::<IndexMap<_, _>>()))
+            } else {
+                Ok(Value::KeyedMap(values))
+            }
         }
         _ => bail!("fromPairs() takes an array as the argument"),
     });

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -47,6 +47,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer {
             Value::Month(value) | Value::Weekday(value) => visitor.visit_u32(value),
             Value::Array(a) => visitor.visit_seq(SeqDeserializer::new(a.into_iter())),
             Value::Map(m) => visitor.visit_map(MapDeserializer::new(m.into_iter())),
+            Value::KeyedMap(m) => visitor.visit_map(MapDeserializer::new(m.into_iter())),
             Value::Nil => visitor.visit_unit(),
         }
     }
@@ -329,14 +330,14 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
 
 #[doc(hidden)]
 pub struct SerializeMap {
-    map: IndexMap<String, Value>,
-    next_key: Option<String>,
+    map: Vec<(Value, Value)>,
+    next_key: Option<Value>,
 }
 
 impl SerializeMap {
     pub fn new() -> Self {
         Self {
-            map: IndexMap::new(),
+            map: Vec::new(),
             next_key: None,
         }
     }
@@ -349,25 +350,27 @@ impl serde::ser::SerializeMap for SerializeMap {
     fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where T: ?Sized + Serialize,
     {
-        match key.serialize(ValueSerializer {})? {
-            Value::String(s) => {
-                self.next_key = Some(s);
-                Ok(())
-            }
-            _ => Err(Error::SerializeError("key must be a string".to_string())),
-        }
+        self.next_key = Some(key.serialize(ValueSerializer {})?);
+        Ok(())
     }
 
     fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where T: ?Sized + Serialize,
     {
         let key = self.next_key.take().expect("serialize_value called before serialize_key");
-        self.map.insert(key, value.serialize(ValueSerializer {})?);
+        self.map.push((key, value.serialize(ValueSerializer {})?));
         Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(Value::Map(self.map))
+        if self.map.iter().all(|(key, _)| matches!(key, Value::String(_))) {
+            Ok(Value::Map(self.map.into_iter().map(|(key, value)| {
+                let Value::String(key) = key else { unreachable!("checked") };
+                (key, value)
+            }).collect()))
+        } else {
+            Ok(Value::KeyedMap(self.map))
+        }
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -124,6 +124,8 @@ pub enum Value {
     // Keep Bytes after Array so untagged serde treats JSON integer arrays as arrays.
     Bytes(Vec<u8>),
     Map(IndexMap<String, Value>),
+    /// A map whose keys are arbitrary expr values.
+    KeyedMap(Vec<(Value, Value)>),
 }
 
 impl Value {
@@ -201,6 +203,13 @@ impl Value {
     pub fn as_map(&self) -> Option<&IndexMap<String, Value>> {
         match self {
             Value::Map(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn as_keyed_map(&self) -> Option<&[(Value, Value)]> {
+        match self {
+            Value::KeyedMap(m) => Some(m),
             _ => None,
         }
     }
@@ -325,6 +334,14 @@ impl Display for Value {
                     .join(", ")
             ),
             Value::Map(m) => write!(
+                f,
+                "{{{}}}",
+                m.iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            Value::KeyedMap(m) => write!(
                 f,
                 "{{{}}}",
                 m.iter()

--- a/tests/go_compat.rs
+++ b/tests/go_compat.rs
@@ -29,6 +29,12 @@ fn json_value(value: ExprValue) -> JsonValue {
                 .map(|(key, value)| (key, json_value(value)))
                 .collect::<Map<_, _>>(),
         ),
+        ExprValue::KeyedMap(values) => JsonValue::Array(
+            values
+                .into_iter()
+                .map(|(key, value)| JsonValue::Array(vec![json_value(key), json_value(value)]))
+                .collect(),
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary

- represent maps with arbitrary expr keys without changing the existing string-map API
- support non-string keys in `fromPairs`, indexing, `get`, membership, `keys`, `values`, and `len`
- preserve arbitrary serde map keys and serialize integer-keyed maps to JSON objects
- sort keyed-map string output like Go and extend the compatibility corpus

## Why

Go expr maps can carry non-string keys, and this was the final value-model gap called out in the v2 compatibility profile.

## Impact

This adds the public `Value::KeyedMap` enum variant, so exhaustive matches over `Value` must handle it. Existing `Value::Map` and `as_map()` behavior remains unchanged for string-keyed maps and structs.

## Stack

Stack #96. Depends on #98.

## Checks

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Go expr v1.17.8 corpus: 175 result lines and 18 error cases

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a breaking public enum variant and changes map behavior across evaluation, serde, and JSON builtins; string-keyed Map paths are preserved but downstream exhaustive matches must be updated.
> 
> **Overview**
> Adds **`Value::KeyedMap`** so maps can use arbitrary expr values as keys while **`Value::Map`** stays string-keyed. **`fromPairs`** builds a keyed map when pair keys are not all strings; serde map serialization follows the same split.
> 
> **Keyed maps** are wired through indexing, **`get`**, **`in` / `not in`** (via **`values_equal`**), **`keys`**, **`values`**, **`len`**, **`toPairs`**, Go-style **`string()`** formatting, and **`toJSON`** (string/integer keys only). **`Context`** still requires string keys and rejects keyed maps.
> 
> The v2 profile and Go compat corpus now cover integer/bool/float keyed maps. Exhaustive **`match` on `Value`** must handle **`KeyedMap`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d3f38510695c0b93c577069e3da20c038bf378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->