### PR TITLE
fix(lib): return errors for malformed built-in calls

### DIFF
--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -173,3 +173,8 @@ len(fromPairs([[1, "one"]]))	1
 string(fromPairs([[10, "ten"], [2, "two"], [1, "one"]]))	"map[1:one 2:two 10:ten]"
 string(fromPairs([[true, "yes"], [false, "no"]]))	"map[false:no true:yes]"
 string(fromPairs([[2.5, "b"], [1.5, "a"]]))	"map[1.5:a 2.5:b]"
+trimPrefix("abc")	"abc"
+trimSuffix("abc")	"abc"
+len(split("abc", ",", 0))	0
+len(splitAfter("a,b", ",", 0))	0
+splitAfter("a,b", ",", -1)	["a,","b"]

--- a/src/functions/string.rs
+++ b/src/functions/string.rs
@@ -15,18 +15,30 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("trimPrefix", |c| {
-        if let (Value::String(s), Value::String(prefix)) = (&c.args[0], &c.args[1]) {
-            Ok(s.strip_prefix(prefix).unwrap_or(s).into())
-        } else {
-            bail!("trimPrefix() takes a string as the first argument and a string to trim as the second argument");
+        if c.args.is_empty() || c.args.len() > 2 {
+            bail!("trimPrefix() takes one or two arguments");
+        }
+        let Value::String(s) = &c.args[0] else {
+            bail!("trimPrefix() takes a string as the first argument");
+        };
+        match c.args.get(1) {
+            Some(Value::String(prefix)) => Ok(s.strip_prefix(prefix).unwrap_or(s).into()),
+            None => Ok(s.into()),
+            Some(_) => bail!("trimPrefix() prefix must be a string"),
         }
     });
 
     env.add_function("trimSuffix", |c| {
-        if let (Value::String(s), Value::String(suffix)) = (&c.args[0], &c.args[1]) {
-            Ok(s.strip_suffix(suffix).unwrap_or(s).into())
-        } else {
-            bail!("trimSuffix() takes a string as the first argument and a string to trim as the second argument");
+        if c.args.is_empty() || c.args.len() > 2 {
+            bail!("trimSuffix() takes one or two arguments");
+        }
+        let Value::String(s) = &c.args[0] else {
+            bail!("trimSuffix() takes a string as the first argument");
+        };
+        match c.args.get(1) {
+            Some(Value::String(suffix)) => Ok(s.strip_suffix(suffix).unwrap_or(s).into()),
+            None => Ok(s.into()),
+            Some(_) => bail!("trimSuffix() suffix must be a string"),
         }
     });
 
@@ -53,6 +65,9 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("split", |c| {
+        if c.args.len() != 2 && c.args.len() != 3 {
+            bail!("split() takes two or three arguments");
+        }
         if let (Value::String(s), Value::String(sep), None) = (&c.args[0], &c.args[1], c.args.get(2)) {
             Ok(s.split(sep).map(Value::from).collect::<Vec<_>>().into())
         } else if let (Value::String(s), Value::String(sep), Some(Value::Integer(n))) = (&c.args[0], &c.args[1], c.args.get(2)) {
@@ -63,11 +78,21 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("splitAfter", |c| {
+        if c.args.len() != 2 && c.args.len() != 3 {
+            bail!("splitAfter() takes two or three arguments");
+        }
         if let (Value::String(s), Value::String(sep), None) = (&c.args[0], &c.args[1], c.args.get(2)) {
             Ok(s.split_inclusive(sep).map(Value::from).collect::<Vec<_>>().into())
         } else if let (Value::String(s), Value::String(sep), Some(Value::Integer(n))) = (&c.args[0], &c.args[1], c.args.get(2)) {
-            let mut arr = s.split_inclusive(sep).take(*n as usize - 1).map(|s| s.to_string()).collect::<Vec<_>>();
-            arr.push(s.split_inclusive(sep).skip(*n as usize - 1).collect::<Vec<_>>().join(""));
+            if *n == 0 {
+                return Ok(Value::Array(Vec::new()));
+            }
+            if *n < 0 {
+                return Ok(s.split_inclusive(sep).map(Value::from).collect::<Vec<_>>().into());
+            }
+            let count = *n as usize;
+            let mut arr = s.split_inclusive(sep).take(count - 1).map(|s| s.to_string()).collect::<Vec<_>>();
+            arr.push(s.split_inclusive(sep).skip(count - 1).collect::<Vec<_>>().join(""));
             Ok(arr.into())
         } else {
             bail!("splitAfter() takes a string as the first argument and a string as the second argument");
@@ -107,6 +132,9 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("indexOf", |c| {
+        if c.args.len() != 2 {
+            bail!("indexOf() takes exactly two arguments");
+        }
         if let (Value::String(s), Value::String(sub)) = (&c.args[0], &c.args[1]) {
             Ok(s.find(sub).map(|i| i as i64).unwrap_or(-1).into())
         } else {
@@ -115,6 +143,9 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("lastIndexOf", |c| {
+        if c.args.len() != 2 {
+            bail!("lastIndexOf() takes exactly two arguments");
+        }
         if let (Value::String(s), Value::String(sub)) = (&c.args[0], &c.args[1]) {
             Ok(s.rfind(sub).map(|i| i as i64).unwrap_or(-1).into())
         } else {
@@ -123,6 +154,9 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("hasPrefix", |c| {
+        if c.args.len() != 2 {
+            bail!("hasPrefix() takes exactly two arguments");
+        }
         if let (Value::String(s), Value::String(prefix)) = (&c.args[0], &c.args[1]) {
             Ok(s.starts_with(prefix).into())
         } else {
@@ -131,6 +165,9 @@ pub fn add_string_functions(env: &mut Environment) {
     });
 
     env.add_function("hasSuffix", |c| {
+        if c.args.len() != 2 {
+            bail!("hasSuffix() takes exactly two arguments");
+        }
         if let (Value::String(s), Value::String(suffix)) = (&c.args[0], &c.args[1]) {
             Ok(s.ends_with(suffix).into())
         } else {

--- a/tests/panic_free.rs
+++ b/tests/panic_free.rs
@@ -1,0 +1,38 @@
+use expr::{Context, eval};
+
+#[test]
+fn malformed_builtin_calls_return_errors_without_panicking() {
+    let context = Context::default();
+    let expressions = [
+        "trimPrefix()",
+        "trimPrefix(1)",
+        r#"trimPrefix("a", "b", "c")"#,
+        "trimSuffix()",
+        "split()",
+        r#"split("a")"#,
+        "splitAfter()",
+        r#"indexOf("a")"#,
+        r#"lastIndexOf("a")"#,
+        r#"hasPrefix("a")"#,
+        r#"hasSuffix("a")"#,
+    ];
+
+    for expression in expressions {
+        let result = std::panic::catch_unwind(|| eval(expression, &context));
+        assert!(result.is_ok(), "{expression:?} panicked");
+        assert!(result.unwrap().is_err(), "{expression:?} unexpectedly succeeded");
+    }
+}
+
+#[test]
+fn split_after_handles_zero_and_negative_limits() {
+    let context = Context::default();
+    assert_eq!(
+        eval(r#"splitAfter("a,b", ",", 0)"#, &context).unwrap(),
+        expr::Value::Array(Vec::new())
+    );
+    assert_eq!(
+        eval(r#"splitAfter("a,b", ",", -1)"#, &context).unwrap(),
+        expr::Value::Array(vec!["a,".into(), "b".into()])
+    );
+}


### PR DESCRIPTION
## Summary

- validate string built-in arity before indexing arguments
- match Go expr's optional second argument for `trimPrefix` and `trimSuffix`
- handle zero and negative `splitAfter` limits without underflow
- add regression tests proving malformed calls return errors instead of panicking
- extend the Go compatibility corpus with the corrected edge cases

## Why

Several malformed string built-in calls could index missing arguments and panic the host process. An expression evaluator should report invalid programs through `Result`, including when invoked through the lower-level API.

## Impact

No valid existing calls change. Invalid extra arguments are now rejected, and one-argument trim-prefix/suffix calls behave like Go expr.

## Stack

Stack #96. Depends on #99.

## Checks

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Go expr v1.17.8 corpus: 180 result lines and 18 error cases

_This PR description was generated by OpenAI Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior changes are limited to invalid calls and documented Go-compat edge cases; valid expressions are unchanged aside from optional trim args and splitAfter limits.
> 
> **Overview**
> **Hardens string built-ins** so bad calls return `Result` errors instead of panicking when arguments are missing or mis-typed. `trimPrefix` / `trimSuffix` now accept an optional second argument (one-arg form returns the string unchanged, matching Go expr), and extra arguments are rejected.
> 
> **Arity checks** were added up front for `split`, `splitAfter`, `indexOf`, `lastIndexOf`, `hasPrefix`, and `hasSuffix`. **`splitAfter`** with a limit of `0` returns an empty array; a **negative** limit splits on every separator (avoiding usize underflow on the old `n - 1` path).
> 
> Regression coverage lives in **`tests/panic_free.rs`**; **`compat/cases.tsv`** adds the matching Go-style edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59eae4e4103bfe0bdfe68bb1cb7022c222702d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->