### PR TITLE
chore: add zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
## Summary

- add zizmor security analysis for pushes to `main` and pull requests
- upload SARIF findings to GitHub code scanning
- grant only the permissions required by the official integration
- prevent checkout credential persistence and pin both actions by commit

## Validation

- `actionlint .github/workflows/zizmor.yml`
- `zizmor 1.29.0 --format=plain .`

The initial scan found six existing findings in older workflows (two low and four medium). This PR intentionally leaves those visible for separate remediation instead of mixing unrelated workflow changes into the installation.

_This PR was generated by OpenAI Codex._
