### PR TITLE
fix(parse)!: support dynamic ranges and slices

### DIFF
--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -193,3 +193,11 @@ string(1 / 0)	"+Inf"
 duration("1h") * 2	7200000000000
 2 * duration("1h")	7200000000000
 (-9223372036854775807 - 1) % -1	0
+let start = 1; let end = 3; start..end	[1,2,3]
+1 + 1..2 + 2	[2,3,4]
+let index = 1; [10, 20, 30][index]	20
+let start = 1; let end = 3; [10, 20, 30, 40][start:end]	[20,30]
+let end = 2; [10, 20, 30][:end]	[10,20]
+let start = 1; b"abcd"[start:]	"YmNk"
+let start = 1; let end = 3; "abcd"[start:end]	"bc"
+"héllo"[1:3]	"é"

--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -97,6 +97,9 @@ impl From<Pairs<'_, Rule>> for Node {
                 node: Box::new(left),
             })
             .map_infix(|left, operator, right| {
+                if operator.as_rule() == Rule::range_op {
+                    return Node::Range(Box::new(left), Box::new(right));
+                }
                 let operator = operator.into();
                 let compiled_regex = match (&operator, &right) {
                     (Operator::Matches, Node::Value(Value::String(pattern))) => {
@@ -197,12 +200,6 @@ impl From<Pair<'_, Rule>> for Node {
                     map.insert(key, val.into_inner().into());
                 }
                 Node::Value(Value::Map(map))
-            }
-            Rule::range => {
-                let mut inner = pair.into_inner();
-                let start = Box::new(inner.next().unwrap().into());
-                let end = Box::new(inner.next().unwrap().into());
-                Node::Range(start, end)
             }
             rule => unreachable!("Unexpected rule: {rule:?}"),
         }

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -9,7 +9,10 @@ use std::iter::once;
 #[derive(Debug, Clone, strum::Display)]
 pub enum PostfixOperator {
     Index { idx: Box<Node>, optional: bool },
-    Range(Option<i64>, Option<i64>),
+    Range {
+        start: Option<Box<Node>>,
+        end: Option<Box<Node>>,
+    },
     Default(Box<Node>),
     Pipe(Box<Node>),
     Ternary { left: Box<Node>, right: Box<Node> },
@@ -29,7 +32,10 @@ impl PostfixOperator {
             PostfixOperator::Method { args, .. } => {
                 args.iter().any(Node::contains_hash_ident)
             }
-            PostfixOperator::Range(..) => false,
+            PostfixOperator::Range { start, end } => start
+                .iter()
+                .chain(end)
+                .any(|node| node.contains_hash_ident()),
         }
     }
 }
@@ -38,24 +44,36 @@ impl From<Pair<'_, Rule>> for PostfixOperator {
     fn from(pair: Pair<Rule>) -> Self {
         trace!("{:?}={}", pair.as_rule(), pair.as_str());
         match pair.as_rule() {
-            Rule::index_op | Rule::membership_op => PostfixOperator::Index {
+            Rule::index_op => PostfixOperator::Index {
                 idx: Box::new(pair.into_inner().into()),
                 optional: false,
             },
-            Rule::opt_index_op | Rule::opt_membership_op => PostfixOperator::Index {
+            Rule::membership_op => PostfixOperator::Index {
+                idx: Box::new(Node::Value(Value::String(
+                    pair.into_inner().next().unwrap().as_str().to_string(),
+                ))),
+                optional: false,
+            },
+            Rule::opt_index_op => PostfixOperator::Index {
                 idx: Box::new(pair.into_inner().into()),
+                optional: true,
+            },
+            Rule::opt_membership_op => PostfixOperator::Index {
+                idx: Box::new(Node::Value(Value::String(
+                    pair.into_inner().next().unwrap().as_str().to_string(),
+                ))),
                 optional: true,
             },
             Rule::range_start_op => {
                 let mut inner = pair.into_inner();
-                let start = inner.next().map(|p| p.as_str().parse().unwrap());
-                let end = inner.next().map(|p| p.as_str().parse().unwrap());
-                PostfixOperator::Range(start, end)
+                let start = inner.next().map(|p| Box::new(p.into()));
+                let end = inner.next().map(|p| Box::new(p.into()));
+                PostfixOperator::Range { start, end }
             }
             Rule::range_end_op => {
                 let mut inner = pair.into_inner();
-                let end = inner.next().map(|p| p.as_str().parse().unwrap());
-                PostfixOperator::Range(None, end)
+                let end = inner.next().map(|p| Box::new(p.into()));
+                PostfixOperator::Range { start: None, end }
             }
             Rule::default_op => PostfixOperator::Default(Box::new(pair.into_inner().into())),
             Rule::ternary => {
@@ -87,7 +105,7 @@ impl Environment<'_> {
         let value = self.eval_expr(ctx, node)?;
         let result = match operator {
             PostfixOperator::Index { idx, optional } => {
-                let key = self.eval_index_key(ctx, idx)?;
+                let key = self.eval_expr(ctx, idx)?;
                 match (&key, value) {
                     (Value::Integer(idx), Value::Array(arr)) => {
                         let idx = i64_to_idx(*idx, arr.len());
@@ -112,17 +130,27 @@ impl Environment<'_> {
                     _ => bail!("Invalid operand for operator []: {key:?}"),
                 }
             },
-            PostfixOperator::Range(start, end) => match value {
-                Value::Array(arr) => {
-                    let (start, end) = slice_bounds(*start, *end, arr.len());
-                    let result = arr.get(start..end).unwrap_or_default().to_vec();
-                    Value::Array(result)
+            PostfixOperator::Range { start, end } => {
+                let start = self.eval_slice_bound(ctx, start.as_deref())?;
+                let end = self.eval_slice_bound(ctx, end.as_deref())?;
+                match value {
+                    Value::Array(arr) => {
+                        let (start, end) = slice_bounds(start, end, arr.len());
+                        let result = arr.get(start..end).unwrap_or_default().to_vec();
+                        Value::Array(result)
+                    }
+                    Value::Bytes(bytes) => {
+                        let (start, end) = slice_bounds(start, end, bytes.len());
+                        Value::Bytes(bytes.get(start..end).unwrap_or_default().to_vec())
+                    }
+                    Value::String(string) => {
+                        let (start, end) = slice_bounds(start, end, string.len());
+                        Value::String(
+                            String::from_utf8_lossy(&string.as_bytes()[start..end]).into(),
+                        )
+                    }
+                    _ => bail!("Invalid operand for operator []"),
                 }
-                Value::Bytes(bytes) => {
-                    let (start, end) = slice_bounds(*start, *end, bytes.len());
-                    Value::Bytes(bytes.get(start..end).unwrap_or_default().to_vec())
-                }
-                _ => bail!("Invalid operand for operator []"),
             },
             PostfixOperator::Default(default) => match value {
                 Value::Nil => self.eval_expr(ctx, default)?,
@@ -160,11 +188,17 @@ impl Environment<'_> {
         Ok(result)
     }
 
-    fn eval_index_key(&self, ctx: &dyn ContextProvider, idx: &Node) -> Result<Value> {
-        match idx {
-            Node::Value(v) => Ok(v.clone()),
-            Node::Ident(id) => Ok(Value::String(id.clone())),
-            idx => self.eval_expr(ctx, idx),
+    fn eval_slice_bound(
+        &self,
+        ctx: &dyn ContextProvider,
+        bound: Option<&Node>,
+    ) -> Result<Option<i64>> {
+        match bound {
+            Some(bound) => match self.eval_expr(ctx, bound)? {
+                Value::Integer(value) => Ok(Some(value)),
+                value => bail!("Invalid slice index: {value:?}"),
+            },
+            None => Ok(None),
         }
     }
 }

--- a/src/expr.pest
+++ b/src/expr.pest
@@ -4,14 +4,14 @@ stmt    =  { "let" ~ ident ~ "=" ~ expr ~ ";" }
 expr    =  { prefix? ~ term ~ postfix* ~ (infix ~ prefix? ~ term ~ postfix*)* }
 
 prefix  = _{ negation_op | sign_op }
-infix   = _{ exponent_op | multiplication_op | addition_op | comparison_op | equal_op | and_op | or_op | not_in_op | string_op }
+infix   = _{ exponent_op | multiplication_op | addition_op | range_op | comparison_op | equal_op | and_op | or_op | not_in_op | string_op }
 postfix = _{ ternary | range_start_op | range_end_op | method_call | opt_membership_op | opt_index_op | membership_op | index_op | default_op | pipe }
 
 func                   =  { ident ~ "(" ~ (expr ~ ("," ~ expr)*)? ~ (","? ~ predicate ~ ("," ~ expr)*)? ~ ")" }
 pipe                   =  { "|" ~ func }
 method_call            =  { "." ~ ident ~ "(" ~ (expr ~ ("," ~ expr)*)? ~ ")" }
 predicate              =  { "." ~ ident | "{" ~ program ~ "}" }
-term                   = _{ conditional_if | func | range | value | ident | array | map | "(" ~ expr ~ ")" }
+term                   = _{ conditional_if | func | value | ident | array | map | "(" ~ expr ~ ")" }
 conditional_if         =  { if_keyword ~ expr ~ block ~ else_keyword ~ (conditional_if | block) }
 if_keyword             = _{ !if_identifier_prefix ~ "if" }
 else_keyword           = _{ !else_identifier_prefix ~ "else" }
@@ -31,6 +31,7 @@ sign_op                =  { "+" | "-" }
 exponent_op            =  { "**" | "^" }
 multiplication_op      =  { "*" | "/" | "%" }
 addition_op            =  { "+" | "-" }
+range_op               =  { ".." }
 comparison_op          =  { "<=" | ">=" | "<" | ">" }
 equal_op               =  { "==" | "!=" }
 and_op                 =  { "&&" | "and" }
@@ -41,7 +42,6 @@ value              =  { bytes | string | string_multiline | decimal | int | bool
 array              =  { "[" ~ (expr ~ ("," ~ expr)* ~ ","?)? ~ "]" }
 map                =  { "{" ~ (map_key ~ ":" ~ expr ~ ("," ~ map_key ~ ":" ~ expr)* ~ ","?)? ~ "}" }
 map_key            = _{ ident | string }
-range              =  { value ~ ".." ~ value }
 string             = ${ ("\"" ~ inner_double ~ "\"" | "'" ~ inner_single ~ "'") }
 bytes              = ${ ("b" | "B") ~ ("\"" ~ inner_bytes_double ~ "\"" | "'" ~ inner_bytes_single ~ "'") }
 string_multiline   = ${ "`" ~ inner_multiline ~ "`" }

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -15,6 +15,7 @@ pub(crate) static PRATT_PARSER: Lazy<PrattParser<Rule>> = Lazy::new(|| {
             | Op::infix(comparison_op, Left)
             | Op::infix(not_in_op, Left)
             | Op::infix(string_op, Left))
+        .op(Op::infix(range_op, Left))
         .op(Op::infix(addition_op, Left))
         .op(Op::prefix(negation_op))
         .op(Op::infix(multiplication_op, Left))

--- a/src/test.rs
+++ b/src/test.rs
@@ -394,6 +394,27 @@ fn nil_coalesce() -> Result<()> {
 #[test]
 fn range() -> Result<()> {
     test_old!("1..3 == [1, 2, 3]", "true");
+    test_old!(
+        "let start = 1; let end = 3; start..end == [1, 2, 3]",
+        "true"
+    );
+    test_old!("1 + 1..2 + 2 == [2, 3, 4]", "true");
+    Ok(())
+}
+
+#[test]
+fn dynamic_indexes_and_slices() -> Result<()> {
+    test_old!("let index = 1; [10, 20, 30][index]", "20");
+    test_old!(
+        "let start = 1; let end = 3; [10, 20, 30, 40][start:end]",
+        "[20, 30]"
+    );
+    test_old!("let end = 2; [10, 20, 30][:end]", "[10, 20]");
+    test_old!("let start = 1; b\"abcd\"[start:]", "[98 99 100]");
+    test_old!("let start = 1; let end = 3; \"abcd\"[start:end]", "\"bc\"");
+    test_old!("\"héllo\"[1:3]", "\"é\"");
+    test_old!("\"é\"[0:1]", "\"�\"");
+    test_old!("{foo: 42}.foo", "42");
     Ok(())
 }
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

## Summary

- parse `..` as an infix operator so range endpoints can be expressions
- evaluate bracket indexes and slice bounds at runtime
- add byte-oriented string slicing alongside array and byte slicing
- keep dot membership as literal property access while making `value[index]` dynamic

## Breaking change

Bare identifiers inside brackets are now evaluated, matching Go expr. Use dot access or a quoted string for a literal map key.

## Verification

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 203 result cases and 22 rejection cases verified against Go expr v1.17.8

## Stack

1. This PR
2. #105
3. #106
4. #107

_This PR description was generated by Codex._