### PR TITLE
fix(lib)!: align arbitrary map key semantics

### DIFF
--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -205,3 +205,12 @@ len("é🙂")	2
 sum([9223372036854775807, 1])	-9223372036854775808
 abs(-9223372036854775807 - 1)	-9223372036854775808
 uniq([1, 1.0, 2, 2.0])	[1,2]
+len(fromPairs([[1, "int"], [1.0, "float"]]))	2
+get(fromPairs([[1, "int"], [1.0, "float"]]), 1)	"int"
+get(fromPairs([[1, "int"], [1.0, "float"]]), 1.0)	"float"
+1 in fromPairs([[1.0, "float"]])	false
+groupBy(1..9, # % 2)[0]	[2,4,6,8]
+groupBy(1..3, # > 1)[true]	[2,3]
+groupBy(1..3, # > 1 ? nil : "")[nil]	[2,3]
+groupBy([1, 1.0], #)[1]	[1]
+groupBy([1, 1.0], #)[1.0]	[1]

--- a/compat/errors.tsv
+++ b/compat/errors.tsv
@@ -21,3 +21,7 @@ duration("1h") / 2
 duration("1h") / duration("30m")
 -duration("1h")
 duration("1h").Seconds(1)
+fromPairs([[[1], "value"]])
+groupBy([[1]], #)
+toJSON(fromPairs([["key", "value"]]))
+fromPairs([["a", 1]]) == {a: 1}

--- a/compat/errors.tsv
+++ b/compat/errors.tsv
@@ -25,3 +25,4 @@ fromPairs([[[1], "value"]])
 groupBy([[1]], #)
 toJSON(fromPairs([["key", "value"]]))
 fromPairs([["a", 1]]) == {a: 1}
+fromPairs([[1, "one"]]) contains 1

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,5 +1,5 @@
 use crate::ast::node::Node;
-use crate::Value::{Array, Bool, DateTime, Duration, Float, Integer, KeyedMap, Map, Month, String, Weekday};
+use crate::Value::{Array, Bool, Bytes, DateTime, Duration, Float, Integer, KeyedMap, Map, Month, String, Weekday};
 use crate::{bail, Result, Rule};
 use crate::{ContextProvider, Environment, Value};
 use log::trace;
@@ -86,13 +86,24 @@ pub(crate) fn values_equal(left: &Value, right: &Value) -> bool {
             left.len() == right.len()
                 && left.iter().all(|(left_key, left_value)| {
                     right.iter().any(|(right_key, right_value)| {
-                        values_equal(left_key, right_key)
+                        map_keys_equal(left_key, right_key)
                             && values_equal(left_value, right_value)
                     })
                 })
         }
         _ => left == right,
     }
+}
+
+pub(crate) fn is_comparable_map_key(value: &Value) -> bool {
+    !matches!(
+        value,
+        Array(_) | Bytes(_) | Map(_) | KeyedMap(_)
+    )
+}
+
+pub(crate) fn map_keys_equal(left: &Value, right: &Value) -> bool {
+    std::mem::discriminant(left) == std::mem::discriminant(right) && left == right
 }
 
 impl Environment<'_> {
@@ -197,11 +208,17 @@ impl Environment<'_> {
                 | (Integer(_), Month(_) | Weekday(_)) => {
                     bail!("Invalid operands for operator {operator}")
                 }
+                (Map(_), KeyedMap(_)) | (KeyedMap(_), Map(_)) => {
+                    bail!("Invalid operands for operator {operator}")
+                }
                 _ => Bool(values_equal(&left, &right)),
             },
             Operator::NotEqual => match (&left, &right) {
                 (Month(_) | Weekday(_), Integer(_))
                 | (Integer(_), Month(_) | Weekday(_)) => {
+                    bail!("Invalid operands for operator {operator}")
+                }
+                (Map(_), KeyedMap(_)) | (KeyedMap(_), Map(_)) => {
                     bail!("Invalid operands for operator {operator}")
                 }
                 _ => Bool(!values_equal(&left, &right)),
@@ -251,7 +268,7 @@ impl Environment<'_> {
                 (String(left), Map(right)) => right.contains_key(&left).into(),
                 (left, KeyedMap(right)) => right
                     .iter()
-                    .any(|(key, _)| values_equal(&left, key))
+                    .any(|(key, _)| map_keys_equal(&left, key))
                     .into(),
                 (left, Array(right)) => right
                     .iter()
@@ -263,7 +280,7 @@ impl Environment<'_> {
                 (String(left), Map(right)) => (!right.contains_key(&left)).into(),
                 (left, KeyedMap(right)) => (!right
                     .iter()
-                    .any(|(key, _)| values_equal(&left, key)))
+                    .any(|(key, _)| map_keys_equal(&left, key)))
                     .into(),
                 (left, Array(right)) => (!right.iter().any(|right| values_equal(&left, right))).into(),
                 _ => bail!("Invalid operands for operator {operator}"),

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -123,7 +123,9 @@ impl Environment<'_> {
                     }
                     (key, Value::KeyedMap(map)) => map
                         .into_iter()
-                        .find(|(candidate, _)| crate::ast::operator::values_equal(key, candidate))
+                        .find(|(candidate, _)| {
+                            crate::ast::operator::map_keys_equal(key, candidate)
+                        })
                         .map(|(_, value)| value)
                         .unwrap_or(Value::Nil),
                     (_, _) if *optional => Value::Nil,

--- a/src/functions/array.rs
+++ b/src/functions/array.rs
@@ -1,5 +1,4 @@
 use crate::{bail, Environment, Value};
-use indexmap::IndexMap;
 
 fn add_sum(total: Value, value: Value) -> crate::Result<Value> {
     match (total, value) {
@@ -295,19 +294,28 @@ pub fn add_array_functions(env: &mut Environment) {
             bail!("groupBy() takes exactly two arguments");
         }
         if let (Value::Array(a), Some(predicate)) = (&c.args[0], c.predicate) {
-            let mut groups = IndexMap::new();
+            let mut groups: Vec<(Value, Vec<Value>)> = Vec::new();
             for value in a {
-                if let Some(key) = c
+                let key = c
                     .env
-                    .run_with_binding(predicate, c.ctx, "#", value.clone())?
-                    .as_string()
-                {
-                    groups.entry(key.to_string()).or_insert_with(Vec::new).push(value.clone());
+                    .run_with_binding(predicate, c.ctx, "#", value.clone())?;
+                if !crate::ast::operator::is_comparable_map_key(&key) {
+                    bail!("groupBy() predicate returned a non-comparable key");
+                }
+                if let Some((_, group)) = groups.iter_mut().find(|(candidate, _)| {
+                    crate::ast::operator::map_keys_equal(candidate, &key)
+                }) {
+                    group.push(value.clone());
                 } else {
-                    bail!("groupBy() predicate must return a string");
+                    groups.push((key, vec![value.clone()]));
                 }
             }
-            Ok(Value::Map(groups.into_iter().map(|(k, group)| (k, group.into())).collect()))
+            Ok(Value::KeyedMap(
+                groups
+                    .into_iter()
+                    .map(|(key, group)| (key, Value::Array(group)))
+                    .collect(),
+            ))
         } else {
             bail!("groupBy() takes an array as the first argument and a predicate as the second argument");
         }

--- a/src/functions/json.rs
+++ b/src/functions/json.rs
@@ -59,18 +59,7 @@ fn value_to_json(value: &Value) -> Result<serde_json::Value> {
                     .collect::<Result<_>>()?
             )
         }
-        Value::KeyedMap(m) => serde_json::Value::Object(
-            m.iter()
-                .map(|(key, value)| {
-                    let key = match key {
-                        Value::String(key) => key.clone(),
-                        Value::Integer(key) => key.to_string(),
-                        _ => bail!("toJSON() map keys must be strings or integers"),
-                    };
-                    Ok((key, value_to_json(value)?))
-                })
-                .collect::<Result<_>>()?
-        ),
+        Value::KeyedMap(_) => bail!("toJSON() does not support arbitrary-key maps"),
     })
 }
 

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -1,7 +1,6 @@
 use crate::{Environment, Error, Value, bail};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
-use indexmap::IndexMap;
 
 fn one_argument(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
     if args.len() != 1 {
@@ -68,7 +67,7 @@ pub fn add_misc_functions(env: &mut Environment) {
             }
             (Value::KeyedMap(values), key) => Ok(values
                 .iter()
-                .find(|(candidate, _)| crate::ast::operator::values_equal(candidate, key))
+                .find(|(candidate, _)| crate::ast::operator::map_keys_equal(candidate, key))
                 .map(|(_, value)| value.clone())
                 .unwrap_or_default()),
             _ => bail!("get() takes an array or bytes and integer, or a map and key"),
@@ -117,8 +116,11 @@ pub fn add_misc_functions(env: &mut Environment) {
                         let mut pair = pair.into_iter();
                         let key = pair.next().expect("length checked");
                         let value = pair.next().expect("length checked");
+                        if !crate::ast::operator::is_comparable_map_key(&key) {
+                            bail!("fromPairs() map key is not comparable");
+                        }
                         if let Some((_, existing)) = values.iter_mut().find(|(candidate, _)| {
-                            crate::ast::operator::values_equal(candidate, &key)
+                            crate::ast::operator::map_keys_equal(candidate, &key)
                         }) {
                             *existing = value;
                         } else {
@@ -128,14 +130,7 @@ pub fn add_misc_functions(env: &mut Environment) {
                     _ => bail!("fromPairs() expects an array of two-element arrays"),
                 }
             }
-            if values.iter().all(|(key, _)| matches!(key, Value::String(_))) {
-                Ok(Value::Map(values.into_iter().map(|(key, value)| {
-                    let Value::String(key) = key else { unreachable!("checked") };
-                    (key, value)
-                }).collect::<IndexMap<_, _>>()))
-            } else {
-                Ok(Value::KeyedMap(values))
-            }
+            Ok(Value::KeyedMap(values))
         }
         _ => bail!("fromPairs() takes an array as the argument"),
     });


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

## Summary

- distinguish map keys by concrete type, so `1` and `1.0` remain separate
- let `groupBy` return comparable integer, float, bool, nil, and string keys
- reject array, byte, and map keys as non-comparable
- align lookup, membership, equality, `fromPairs`, and `toJSON` behavior

## Breaking change

`fromPairs` and `groupBy` now retain arbitrary-key map semantics, and keyed maps no longer use numeric expression equality for key identity.

## Verification

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 216 result cases and 27 rejection cases verified against Go expr v1.17.8

## Stack

1. #104
2. #105
3. This PR
4. #107

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking runtime semantics for maps and several builtins; changes are scoped to value comparison and collection APIs, not security or I/O.
> 
> **Overview**
> **Breaking:** keyed maps now treat keys by **concrete type and value**, so `1` and `1.0` are distinct keys for lookup, `in`, equality, `get`, and `[]`.
> 
> `fromPairs` always builds a `KeyedMap` (no promotion to string `Map`), rejects non-comparable keys (arrays, bytes, nested maps), and duplicate keys merge via `map_keys_equal`. `groupBy` returns a `KeyedMap` keyed by the predicate’s return value (int, float, bool, nil, string, etc.) instead of requiring string keys and a string `Map`. `toJSON` errors on arbitrary-key maps; comparing or mixing `Map` with `KeyedMap` via `==` / `!=` is rejected.
> 
> Shared helpers `is_comparable_map_key` and `map_keys_equal` centralize this behavior across operators, postfix indexing, and misc/array builtins. Compat cases cover `fromPairs`/`groupBy` and new error expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99786c0912c413f95de0f6bdda8e9a502add9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->