### PR TITLE
fix(lib)!: preserve temporal timezone semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "base64",
  "chrono",
  "chrono-tz",
+ "iana-time-zone",
  "indexmap",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ name = "expr"
 base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.10", features = ["serde"] }
+iana-time-zone = "0.1"
 indexmap = "2"
 regex = "1"
 thiserror = "2"

--- a/compat/cases.tsv
+++ b/compat/cases.tsv
@@ -244,3 +244,12 @@ date("2023-01-02T03:04:05+02:30:15", "2006-01-02T15:04:05-07:00:00").Format("-07
 date(timezone("Europe/Zurich"), "2023-03-25T12:00:00", "2006-01-02T15:04:05").AddDate(0, 0, 1).Format("2006-01-02T15:04:05Z07:00")	"2023-03-26T12:00:00+02:00"
 date("2023-08-14T01:29:31+02:00").Round(duration("1h")).Format("15:04:05-07:00")	"01:00:00+02:00"
 date("4 Aug 2023 PST", "2 Jan 2006 MST").Format("MST -0700")	"PST +0000"
+date(timezone("America/New_York"), "2023-03-12T01:30:00", "2006-01-02T15:04:05").Add(duration("1h")).Format("2006-01-02T15:04:05Z07:00")	"2023-03-12T03:30:00-04:00"
+date(timezone("America/New_York"), "2023-03-12T01:31:00", "2006-01-02T15:04:05").Round(duration("1h")).Format("2006-01-02T15:04:05Z07:00")	"2023-03-12T03:00:00-04:00"
+date(timezone("America/New_York"), "2023-03-12T03:30:00", "2006-01-02T15:04:05").Truncate(duration("2h")).Format("2006-01-02T15:04:05Z07:00")	"2023-03-12T01:00:00-05:00"
+date("0001-01-01T01:00:00+01:00").IsZero()	true
+date("2023-01-02T03:04:05.120Z").Format("5.000 5.999")	"5.120 5.12"
+date("2023-01-02T03:04:05.120Z", "2006-01-02T15:04:5.000Z07:00")	"2023-01-02T03:04:05.12Z"
+date("2023-08-14").Local().Location().String()	"Local"
+timezone("Local").String()	"Local"
+date("2023-08-14", "2006-01-02", "Local").Location().String()	"Local"

--- a/src/functions/temporal.rs
+++ b/src/functions/temporal.rs
@@ -1,5 +1,5 @@
-use crate::{bail, value::DateTimeValue, Environment, Error, Value};
-use chrono::{DateTime, Datelike, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc};
+use crate::{bail, value::{DateTimeValue, TimezoneValue}, Environment, Error, Value};
+use chrono::{DateTime, Datelike, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc};
 use chrono_tz::{OffsetComponents, Tz};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -42,13 +42,22 @@ pub fn add_temporal_functions(env: &mut Environment) {
         let Value::String(value) = call.args.pop().expect("length checked") else {
             bail!("timezone() takes a string");
         };
-        value
-            .parse::<Tz>()
-            .map(Value::Timezone)
-            .map_err(|error| Error::ExprError(format!("invalid timezone {value}: {error}")))
+        parse_timezone(&value).map(Value::Timezone)
     });
 
     env.add_function("date", |call| parse_date(call.args).map(Value::DateTime));
+}
+
+fn parse_timezone(value: &str) -> crate::Result<TimezoneValue> {
+    if value == "Local" {
+        TimezoneValue::local()
+            .map_err(|error| Error::ExprError(format!("invalid local timezone: {error}")))
+    } else {
+        value
+            .parse::<Tz>()
+            .map(TimezoneValue::named)
+            .map_err(|error| Error::ExprError(format!("invalid timezone {value}: {error}")))
+    }
 }
 
 fn parse_duration(value: &str) -> crate::Result<i64> {
@@ -120,11 +129,9 @@ fn parse_date(mut args: Vec<Value>) -> crate::Result<DateTimeValue> {
         bail!("date() first argument must be a string");
     };
     let timezone = match args.get(2) {
-        Some(Value::String(value)) => value
-            .parse::<Tz>()
-            .map_err(|error| Error::ExprError(format!("invalid timezone {value}: {error}")))?,
+        Some(Value::String(value)) => parse_timezone(value)?,
         Some(_) => bail!("date() timezone must be a string"),
-        None => leading_timezone.unwrap_or(chrono_tz::UTC),
+        None => leading_timezone.unwrap_or_else(|| TimezoneValue::named(chrono_tz::UTC)),
     };
 
     if let Some(layout) = args.get(1) {
@@ -212,7 +219,11 @@ fn parse_date(mut args: Vec<Value>) -> crate::Result<DateTimeValue> {
     bail!("invalid date {value}")
 }
 
-fn parse_in_timezone(value: &str, format: &str, timezone: Tz) -> crate::Result<DateTimeValue> {
+fn parse_in_timezone(
+    value: &str,
+    format: &str,
+    timezone: TimezoneValue,
+) -> crate::Result<DateTimeValue> {
     if format.contains("%z")
         || format.contains("%:z")
         || format.contains("%::z")
@@ -238,6 +249,7 @@ fn parse_in_timezone(value: &str, format: &str, timezone: Tz) -> crate::Result<D
         bail!("invalid date {value}");
     };
     timezone
+        .timezone()
         .from_local_datetime(&naive)
         .earliest()
         .map(|value| DateTimeValue::zoned(value, timezone))
@@ -283,7 +295,7 @@ fn go_layout_to_chrono(layout: &str) -> String {
     let mut output = String::new();
     let mut remaining = layout;
     while !remaining.is_empty() {
-        if output.ends_with("%S") {
+        if output.ends_with("%S") || output.ends_with("%-S") {
             if let Some((separator, digits)) = fractional_layout(remaining) {
                 output.push_str("%.f");
                 remaining = &remaining[separator.len_utf8() + digits..];
@@ -314,7 +326,8 @@ fn format_go_layout(value: &DateTimeValue, layout: &str) -> String {
     let mut chrono_layout = String::new();
     let mut remaining = layout;
     while !remaining.is_empty() {
-        if go_layout_to_chrono(&chrono_layout).ends_with("%S") {
+        let converted_layout = go_layout_to_chrono(&chrono_layout);
+        if converted_layout.ends_with("%S") || converted_layout.ends_with("%-S") {
             if let Some((separator, digits)) = fractional_layout(remaining) {
                 output.push_str(&value.format(&go_layout_to_chrono(&chrono_layout)).to_string());
                 chrono_layout.clear();
@@ -468,8 +481,8 @@ pub(crate) fn eval_method(receiver: Value, method: &str, args: Vec<Value>) -> cr
             Ok(Value::Bool(value == other))
         }
         (Value::DateTime(value), "IsDST") => {
-            let is_dst = value.named_timezone().is_some_and(|timezone| {
-                timezone
+            let is_dst = value.timezone().is_some_and(|timezone| {
+                timezone.timezone()
                     .offset_from_utc_datetime(&value.naive_utc())
                     .dst_offset()
                     != Duration::zero()
@@ -480,16 +493,16 @@ pub(crate) fn eval_method(receiver: Value, method: &str, args: Vec<Value>) -> cr
             method,
             args,
             Value::Bool(
-                value.year() == 1
-                    && value.month() == 1
-                    && value.day() == 1
-                    && value.time() == NaiveTime::MIN
-                    && value.offset().local_minus_utc() == 0,
+                value.naive_utc()
+                    == NaiveDate::from_ymd_opt(1, 1, 1)
+                        .expect("valid zero date")
+                        .and_time(NaiveTime::MIN),
             ),
         ),
         (Value::DateTime(value), "Location") => {
-            let timezone = value.named_timezone().or_else(|| {
-                (value.offset().local_minus_utc() == 0).then_some(chrono_tz::UTC)
+            let timezone = value.timezone().or_else(|| {
+                (value.offset().local_minus_utc() == 0)
+                    .then_some(TimezoneValue::named(chrono_tz::UTC))
             });
             let timezone = timezone.ok_or_else(|| {
                 Error::ExprError("fixed-offset date has no named timezone".to_string())
@@ -499,14 +512,12 @@ pub(crate) fn eval_method(receiver: Value, method: &str, args: Vec<Value>) -> cr
         (Value::DateTime(value), "UTC") => no_args(
             method,
             args,
-            Value::DateTime(value.with_timezone(chrono_tz::UTC)),
+            Value::DateTime(value.with_timezone(TimezoneValue::named(chrono_tz::UTC))),
         ),
         (Value::DateTime(value), "Local") => {
-            let local = Utc
-                .from_utc_datetime(&value.naive_utc())
-                .with_timezone(&Local)
-                .fixed_offset();
-            no_args(method, args, Value::DateTime(DateTimeValue::fixed(local)))
+            let timezone = TimezoneValue::local()
+                .map_err(|error| Error::ExprError(format!("invalid local timezone: {error}")))?;
+            no_args(method, args, Value::DateTime(value.with_timezone(timezone)))
         }
         (Value::DateTime(value), "Round") => {
             let unit = one_duration_arg(method, args)?;
@@ -600,8 +611,9 @@ fn add_date(value: DateTimeValue, years: i64, months: i64, days: i64) -> crate::
     let naive = NaiveDate::from_ymd_opt(year, month, 1)
         .and_then(|date| date.and_time(value.time()).checked_add_signed(Duration::days(day_offset)))
         .ok_or_else(|| Error::ExprError("date out of range".to_string()))?;
-    if let Some(timezone) = value.named_timezone() {
+    if let Some(timezone) = value.timezone() {
         timezone
+            .timezone()
             .from_local_datetime(&naive)
             .earliest()
             .map(|value| DateTimeValue::zoned(value, timezone))
@@ -750,4 +762,29 @@ pub(crate) fn format_datetime(value: &DateTimeValue) -> String {
     output.push(' ');
     output.push_str(&value.zone_name());
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_location_retains_dst_rules() {
+        let timezone = TimezoneValue::local_with_timezone(chrono_tz::America::New_York);
+        let value = timezone
+            .timezone()
+            .with_ymd_and_hms(2023, 8, 14, 12, 0, 0)
+            .single()
+            .expect("valid local date");
+        let value = DateTimeValue::zoned(value, timezone);
+
+        assert_eq!(
+            eval_method(Value::DateTime(value.clone()), "Location", vec![]).unwrap(),
+            Value::Timezone(timezone)
+        );
+        assert_eq!(
+            eval_method(Value::DateTime(value), "IsDST", vec![]).unwrap(),
+            Value::Bool(true)
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::parser::compile;
 #[allow(deprecated)]
 pub use crate::parser::Parser;
 pub use crate::ast::program::Program;
-pub use crate::value::{DateTimeValue, Value};
+pub use crate::value::{DateTimeValue, TimezoneValue, Value};
 #[cfg(feature = "serde")]
 pub use crate::serde::{from_value, to_value};
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,7 +15,7 @@ use std::ops::{Add, Deref, Sub};
 pub struct DateTimeValue {
     value: chrono::DateTime<chrono::FixedOffset>,
     #[cfg_attr(feature = "serde", serde(skip))]
-    timezone: Option<chrono_tz::Tz>,
+    timezone: Option<TimezoneValue>,
     #[cfg_attr(feature = "serde", serde(skip))]
     zone_name: Option<String>,
 }
@@ -25,15 +25,22 @@ impl DateTimeValue {
         Self { value, timezone: None, zone_name: None }
     }
 
-    pub fn zoned(value: chrono::DateTime<chrono_tz::Tz>, timezone: chrono_tz::Tz) -> Self {
-        Self { value: value.fixed_offset(), timezone: Some(timezone), zone_name: None }
+    pub fn zoned(
+        value: chrono::DateTime<chrono_tz::Tz>,
+        timezone: impl Into<TimezoneValue>,
+    ) -> Self {
+        Self {
+            value: value.fixed_offset(),
+            timezone: Some(timezone.into()),
+            zone_name: None,
+        }
     }
 
-    pub(crate) fn with_timezone(&self, timezone: chrono_tz::Tz) -> Self {
-        Self::zoned(self.value.with_timezone(&timezone), timezone)
+    pub(crate) fn with_timezone(&self, timezone: TimezoneValue) -> Self {
+        Self::zoned(self.value.with_timezone(&timezone.timezone()), timezone)
     }
 
-    pub(crate) fn named_timezone(&self) -> Option<chrono_tz::Tz> {
+    pub(crate) fn timezone(&self) -> Option<TimezoneValue> {
         self.timezone
     }
 
@@ -44,12 +51,20 @@ impl DateTimeValue {
 
     pub fn checked_add_signed(mut self, duration: chrono::Duration) -> Option<Self> {
         self.value = self.value.checked_add_signed(duration)?;
+        self.refresh_timezone();
         Some(self)
     }
 
     pub fn checked_sub_signed(mut self, duration: chrono::Duration) -> Option<Self> {
         self.value = self.value.checked_sub_signed(duration)?;
+        self.refresh_timezone();
         Some(self)
+    }
+
+    fn refresh_timezone(&mut self) {
+        if let Some(timezone) = self.timezone {
+            self.value = self.value.with_timezone(&timezone.timezone()).fixed_offset();
+        }
     }
 
     pub(crate) fn zone_name(&self) -> String {
@@ -57,7 +72,10 @@ impl DateTimeValue {
             return zone_name.clone();
         }
         if let Some(timezone) = self.timezone {
-            self.value.with_timezone(&timezone).format("%Z").to_string()
+            self.value
+                .with_timezone(&timezone.timezone())
+                .format("%Z")
+                .to_string()
         } else if self.value.offset().local_minus_utc() == 0 {
             "UTC".to_string()
         } else {
@@ -97,6 +115,7 @@ impl Add<chrono::Duration> for DateTimeValue {
 
     fn add(mut self, duration: chrono::Duration) -> Self::Output {
         self.value += duration;
+        self.refresh_timezone();
         self
     }
 }
@@ -106,7 +125,82 @@ impl Sub<chrono::Duration> for DateTimeValue {
 
     fn sub(mut self, duration: chrono::Duration) -> Self::Output {
         self.value -= duration;
+        self.refresh_timezone();
         self
+    }
+}
+
+/// A timezone used by expr time values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct TimezoneValue {
+    timezone: chrono_tz::Tz,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    local: bool,
+}
+
+impl TimezoneValue {
+    /// Creates a named IANA timezone.
+    pub fn named(timezone: chrono_tz::Tz) -> Self {
+        Self { timezone, local: false }
+    }
+
+    /// Resolves the process-local timezone.
+    pub fn local() -> Result<Self, String> {
+        let timezone = std::env::var("TZ")
+            .ok()
+            .and_then(|timezone| {
+                timezone
+                    .strip_prefix(':')
+                    .unwrap_or(&timezone)
+                    .parse::<chrono_tz::Tz>()
+                    .ok()
+            })
+            .map(Ok)
+            .unwrap_or_else(|| {
+                iana_time_zone::get_timezone()
+                    .map_err(|error| error.to_string())?
+                    .parse::<chrono_tz::Tz>()
+                    .map_err(|error| error.to_string())
+            })?;
+        Ok(Self { timezone, local: true })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_with_timezone(timezone: chrono_tz::Tz) -> Self {
+        Self { timezone, local: true }
+    }
+
+    /// Returns the IANA timezone that supplies this location's offset rules.
+    pub fn timezone(self) -> chrono_tz::Tz {
+        self.timezone
+    }
+
+    /// Returns the Go-compatible location name.
+    pub fn name(self) -> &'static str {
+        if self.local {
+            "Local"
+        } else {
+            self.timezone.name()
+        }
+    }
+
+    /// Returns whether this is the process-local location.
+    pub fn is_local(self) -> bool {
+        self.local
+    }
+}
+
+impl From<chrono_tz::Tz> for TimezoneValue {
+    fn from(timezone: chrono_tz::Tz) -> Self {
+        Self::named(timezone)
+    }
+}
+
+impl Display for TimezoneValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
     }
 }
 
@@ -131,7 +225,7 @@ pub enum Value {
     String(String),
     DateTime(DateTimeValue),
     Duration(i64),
-    Timezone(chrono_tz::Tz),
+    Timezone(TimezoneValue),
     Month(u32),
     Weekday(u32),
     Array(Vec<Value>),

--- a/src/value.rs
+++ b/src/value.rs
@@ -148,22 +148,15 @@ impl TimezoneValue {
 
     /// Resolves the process-local timezone.
     pub fn local() -> Result<Self, String> {
-        let timezone = std::env::var("TZ")
-            .ok()
-            .and_then(|timezone| {
-                timezone
-                    .strip_prefix(':')
-                    .unwrap_or(&timezone)
-                    .parse::<chrono_tz::Tz>()
-                    .ok()
-            })
-            .map(Ok)
-            .unwrap_or_else(|| {
+        let timezone = match std::env::var_os("TZ") {
+            Some(timezone) => timezone_from_env(&timezone),
+            None => {
                 iana_time_zone::get_timezone()
                     .map_err(|error| error.to_string())?
                     .parse::<chrono_tz::Tz>()
                     .map_err(|error| error.to_string())
-            })?;
+            }?,
+        };
         Ok(Self { timezone, local: true })
     }
 
@@ -192,6 +185,19 @@ impl TimezoneValue {
     }
 }
 
+fn timezone_from_env(value: &std::ffi::OsStr) -> chrono_tz::Tz {
+    value
+        .to_str()
+        .and_then(|timezone| {
+            timezone
+                .strip_prefix(':')
+                .unwrap_or(timezone)
+                .parse::<chrono_tz::Tz>()
+                .ok()
+        })
+        .unwrap_or(chrono_tz::UTC)
+}
+
 impl From<chrono_tz::Tz> for TimezoneValue {
     fn from(timezone: chrono_tz::Tz) -> Self {
         Self::named(timezone)
@@ -201,6 +207,28 @@ impl From<chrono_tz::Tz> for TimezoneValue {
 impl Display for TimezoneValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod timezone_tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_invalid_tz_environment_values_use_utc() {
+        assert_eq!(timezone_from_env(std::ffi::OsStr::new("")), chrono_tz::UTC);
+        assert_eq!(
+            timezone_from_env(std::ffi::OsStr::new("not-a-timezone")),
+            chrono_tz::UTC
+        );
+    }
+
+    #[test]
+    fn tz_environment_value_accepts_go_colon_prefix() {
+        assert_eq!(
+            timezone_from_env(std::ffi::OsStr::new(":America/New_York")),
+            chrono_tz::America::New_York
+        );
     }
 }
 


### PR DESCRIPTION
Addresses the temporal compatibility findings from the late review on #107: https://github.com/jdx/expr.rs/pull/107#pullrequestreview-4967462038

## Summary

- re-resolve named timezone offsets after time arithmetic crosses DST boundaries
- compare `IsZero()` using the absolute instant
- preserve process-local location identity and DST rules through `Local()`
- recognize fractional seconds after padded and unpadded Go second tokens
- add Go-verified regression cases for all four findings

## Root cause

`DateTimeValue` retained a fixed offset alongside optional named-zone metadata, but arithmetic updated only the fixed offset. Local conversion discarded the location entirely, and fractional-layout recognition only checked Chrono `%S`.

## Breaking change

`Value::Timezone` now contains the exported `TimezoneValue` wrapper instead of `chrono_tz::Tz`, allowing the runtime to distinguish Go-compatible `Local` from its underlying IANA timezone rules.

## Validation

- `mise x go@1.26.5 -- go run .` in `compat`
- `TZ=America/New_York cargo test --test go_compat`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo package --allow-dirty`

_This PR description was AI-generated._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API (`Value::Timezone` / exported `TimezoneValue`) plus DST and local-time behavior changes that can alter evaluation results for existing date expressions.
> 
> **Overview**
> Fixes Go temporal compatibility around **named zones, `Local`, and DST**.
> 
> **`TimezoneValue`** wraps IANA zones and distinguishes Go **`Local`** from a plain named zone (`Value::Timezone` is now this type instead of raw `chrono_tz::Tz`). **`timezone("Local")`** and **`date(..., "Local")`** resolve via `TZ` / `iana-time-zone`; invalid or empty `TZ` falls back to UTC, with Go-style `:Zone` prefixes supported.
> 
> **`DateTimeValue`** re-applies the stored zone after add/sub and checked arithmetic so offsets update when math crosses DST. **`Local()`** keeps local location identity and rules (not a one-shot `chrono::Local` fixed offset). **`IsZero()`** compares the absolute instant to the Go zero time. **`IsDST`**, **`Location`**, and date parsing/formatting route through **`TimezoneValue`**.
> 
> Go layout conversion now treats fractional seconds after both **`%S`** and **`%-S`**. New **`compat/cases.tsv`** cases cover US spring-forward add/round/truncate, zero-with-offset, fractional parse/format, and **`Local`** location strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38868429ec39d29d76ac1e75b51e202355404327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->