### PR TITLE
feat: make the dependency tree optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,16 +210,13 @@ dependencies = [
  "iana-time-zone",
  "indexmap",
  "log",
- "once_cell",
  "pest",
  "pest_derive",
  "proptest",
  "regex",
  "serde",
  "serde_json",
- "strum",
  "test-log",
- "thiserror",
 ]
 
 [[package]]
@@ -292,12 +289,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -727,27 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "strum"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,26 +782,6 @@ checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
  "syn 2.0.119",
  "test-log-core",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,26 +23,42 @@ include = [
 ]
 
 [features]
-serde = ["dep:serde", "indexmap/serde"]
+# Everything is on by default, so an existing dependent sees no change: the whole language is
+# there unless it says otherwise. `default-features = false` is for an embedder that wants the
+# evaluator and knows which builtins its expressions use — a CLI validating flag values does
+# not need a timezone database.
+default = ["base64", "json", "regex", "temporal"]
+
+# `toBase64` / `fromBase64`.
+base64 = ["dep:base64"]
+# `fromJSON` / `toJSON`. Implies `base64`, which is how `toJSON` writes `Value::Bytes`.
+json = ["dep:serde_json", "base64"]
+# The `matches` operator.
+regex = ["dep:regex"]
+# Dates, durations, timezones, and their operators and methods: `now`, `date`, `duration`,
+# `timezone`, and the `Value` variants they produce. Carries the regex crate because parsing
+# a UTC offset uses it — that is not the `matches` operator, which `regex` is.
+temporal = ["dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:regex"]
+
+# `chrono`/`chrono-tz` serde support belongs here rather than on the dependency lines: it
+# pulled serde into every build that did not ask for serde at all.
+serde = ["dep:serde", "indexmap/serde", "chrono?/serde", "chrono-tz?/serde"]
 
 [lib]
 name = "expr"
 
 [dependencies]
-base64 = "0.23"
-chrono = { version = "0.4", features = ["serde"] }
-chrono-tz = { version = "0.10", features = ["serde"] }
-iana-time-zone = "0.1"
+base64 = { version = "0.23", optional = true }
+chrono = { version = "0.4", optional = true }
+chrono-tz = { version = "0.10", optional = true }
+iana-time-zone = { version = "0.1", optional = true }
 indexmap = "2"
-regex = "1"
-thiserror = "2"
+regex = { version = "1", optional = true }
 pest_derive = "2"
 pest = "2"
 log = "0.4"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
-strum = { version = "0.28", features = ["derive"] }
-once_cell = "1"
+serde_json = { version = "1", features = ["preserve_order"], optional = true }
 
 [dev-dependencies]
 test-log = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ serde_json = { version = "1", features = ["preserve_order"], optional = true }
 test-log = "0.2"
 proptest = "1"
 serde = "1"
+# For tests only, and unconditionally: `serde.rs`'s tests read JSON to build a `Value` to
+# round-trip, which has nothing to do with whether the `json` builtins are compiled in.
+serde_json = "1"
 
 [profile.dev]
 debug = 1

--- a/README.md
+++ b/README.md
@@ -66,8 +66,13 @@ That is 14 crates instead of 30. `keys`, `values`, `len`, the string and array b
 arithmetic and comparison operators, and `?:` / `??` / pipes are all in the base: they need
 nothing but the parser.
 
-An expression that reaches a builtin whose feature is off gets an error naming the feature,
-rather than a wrong answer — the grammar has no features, so `matches` still parses.
+The grammar has no features, so an expression using a disabled builtin still parses — and says
+which feature it needs rather than looking like a typo or a wrong answer:
+
+```
+fromJSON() requires expr-lang's `json` feature
+the `matches` operator requires the `regex` feature
+```
 
 ### Serde integration
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ fn main() {
 }
 ```
 
+### Cargo features
+
+Everything is on by default, so nothing changes for a dependent that says nothing. What the
+features are for is the other direction: an embedder that knows which builtins its expressions
+use can leave out the crates behind the rest. A CLI validating flag values with
+`int(value) > 0` does not need a timezone database.
+
+| Feature    | Default | What it enables                                                         | Crates it costs |
+| ---------- | :-----: | ----------------------------------------------------------------------- | --------------: |
+| `temporal` |   yes   | `now`, `date`, `duration`, `timezone`, every `.Year()`-style method, and the datetime/duration/timezone/month/weekday values | 7 |
+| `json`     |   yes   | `fromJSON`, `toJSON` (implies `base64`, which is how `toJSON` writes bytes) | 4 |
+| `regex`    |   yes   | the `matches` operator                                                  | 4 |
+| `base64`   |   yes   | `toBase64`, `fromBase64`                                                | 1 |
+| `serde`    |   no    | `to_value` / `from_value`, and `Serialize`/`Deserialize` for `Value`    | — |
+
+```toml
+# The evaluator, the operators, and every builtin that needs no crate to implement.
+expr-lang = { version = "2", default-features = false }
+```
+
+That is 14 crates instead of 30. `keys`, `values`, `len`, the string and array builtins, the
+arithmetic and comparison operators, and `?:` / `??` / pipes are all in the base: they need
+nothing but the parser.
+
+An expression that reaches a builtin whose feature is off gets an error naming the feature,
+rather than a wrong answer — the grammar has no features, so `matches` still parses.
+
 ### Serde integration
 
 #### Converting expr values to/from rust types

--- a/mise.toml
+++ b/mise.toml
@@ -20,14 +20,21 @@ run = [
 # own, and the empty set — the evaluator with no builtins that need a crate — first.
 [tasks."lint:features"]
 run = [
-  "cargo clippy --lib --no-default-features -- -D warnings",
-  "cargo clippy --lib --no-default-features -F base64 -- -D warnings",
-  "cargo clippy --lib --no-default-features -F json -- -D warnings",
-  "cargo clippy --lib --no-default-features -F regex -- -D warnings",
-  "cargo clippy --lib --no-default-features -F temporal -- -D warnings",
-  "cargo clippy --lib --no-default-features -F serde -- -D warnings",
-  "cargo clippy --lib --no-default-features -F serde,temporal -- -D warnings",
-  "cargo clippy --lib --no-default-features -F json,temporal -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F base64 -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F json -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F regex -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F temporal -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F serde -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F serde,temporal -- -D warnings",
+  "cargo clippy --all-targets --no-default-features -F json,temporal -- -D warnings",
+  # And run them: the tests for what a disabled feature *says* only compile when it is off,
+  # so `cargo test --all-features` can never reach them.
+  "cargo test --no-default-features",
+  "cargo test --no-default-features -F json",
+  "cargo test --no-default-features -F regex",
+  "cargo test --no-default-features -F temporal",
+  "cargo test --no-default-features -F serde",
 ]
 
 [tasks.test]

--- a/mise.toml
+++ b/mise.toml
@@ -9,9 +9,25 @@ watchexec = "latest"
 cargo.binstall_native = true
 
 [tasks.lint]
+depends = ["lint:features"]
 run = [
   "cargo clippy --all-targets --all-features -- -D warnings",
   "pestfmt src/expr.pest",
+]
+
+# The features are subtractive, so `--all-features` is the one combination that proves nothing
+# about them: it is what the crate looked like before they existed. Each one is checked on its
+# own, and the empty set — the evaluator with no builtins that need a crate — first.
+[tasks."lint:features"]
+run = [
+  "cargo clippy --lib --no-default-features -- -D warnings",
+  "cargo clippy --lib --no-default-features -F base64 -- -D warnings",
+  "cargo clippy --lib --no-default-features -F json -- -D warnings",
+  "cargo clippy --lib --no-default-features -F regex -- -D warnings",
+  "cargo clippy --lib --no-default-features -F temporal -- -D warnings",
+  "cargo clippy --lib --no-default-features -F serde -- -D warnings",
+  "cargo clippy --lib --no-default-features -F serde,temporal -- -D warnings",
+  "cargo clippy --lib --no-default-features -F json,temporal -- -D warnings",
 ]
 
 [tasks.test]

--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -23,6 +23,7 @@ pub enum Node {
         operator: Operator,
         left: Box<Node>,
         right: Box<Node>,
+        #[cfg(feature = "regex")]
         compiled_regex: Option<regex::Regex>,
     },
     Postfix {
@@ -101,6 +102,7 @@ impl From<Pairs<'_, Rule>> for Node {
                     return Node::Range(Box::new(left), Box::new(right));
                 }
                 let operator = operator.into();
+                #[cfg(feature = "regex")]
                 let compiled_regex = match (&operator, &right) {
                     (Operator::Matches, Node::Value(Value::String(pattern))) => {
                         regex::Regex::new(pattern).ok()
@@ -111,6 +113,7 @@ impl From<Pairs<'_, Rule>> for Node {
                     operator,
                     left: Box::new(left),
                     right: Box::new(right),
+                    #[cfg(feature = "regex")]
                     compiled_regex,
                 }
             })

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,53 +1,102 @@
 use crate::ast::node::Node;
-use crate::Value::{Array, Bool, Bytes, DateTime, Duration, Float, Integer, KeyedMap, Map, Month, String, Weekday};
+use crate::Value::{Array, Bool, Bytes, Float, Integer, KeyedMap, Map, String};
+#[cfg(feature = "temporal")]
+use crate::Value::{DateTime, Duration, Month, Weekday};
 use crate::{bail, Result, Rule};
 use crate::{ContextProvider, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
-use std::str::FromStr;
+use std::fmt;
 
-#[derive(Debug, Clone, strum::EnumString, strum::Display)]
+#[derive(Debug, Clone)]
 pub enum Operator {
-    #[strum(serialize = "+")]
     Add,
-    #[strum(serialize = "-")]
     Subtract,
-    #[strum(serialize = "*")]
     Multiply,
-    #[strum(serialize = "/")]
     Divide,
-    #[strum(serialize = "%")]
     Modulo,
-    #[strum(serialize = "^")]
     Pow,
-    #[strum(serialize = "==")]
     Equal,
-    #[strum(serialize = "!=")]
     NotEqual,
-    #[strum(serialize = ">")]
     GreaterThan,
-    #[strum(serialize = ">=")]
     GreaterThanOrEqual,
-    #[strum(serialize = "<")]
     LessThan,
-    #[strum(serialize = "<=")]
     LessThanOrEqual,
-    #[strum(serialize = "&&", serialize = "and")]
     And,
-    #[strum(serialize = "||", serialize = "or")]
     Or,
-    #[strum(serialize = "in")]
     In,
-    #[strum(serialize = "not in")]
     NotIn,
-    #[strum(serialize = "contains")]
     Contains,
-    #[strum(serialize = "startsWith")]
     StartsWith,
-    #[strum(serialize = "endsWith")]
     EndsWith,
-    #[strum(serialize = "matches")]
     Matches,
+}
+
+impl Operator {
+    /// How the operator is written in an error message.
+    ///
+    /// The word spelling for `and`/`or`, which is what an expression that reached an error
+    /// most likely used: `&&` and `||` are the same operator by another name.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Operator::Add => "+",
+            Operator::Subtract => "-",
+            Operator::Multiply => "*",
+            Operator::Divide => "/",
+            Operator::Modulo => "%",
+            Operator::Pow => "^",
+            Operator::Equal => "==",
+            Operator::NotEqual => "!=",
+            Operator::GreaterThan => ">",
+            Operator::GreaterThanOrEqual => ">=",
+            Operator::LessThan => "<",
+            Operator::LessThanOrEqual => "<=",
+            Operator::And => "and",
+            Operator::Or => "or",
+            Operator::In => "in",
+            Operator::NotIn => "not in",
+            Operator::Contains => "contains",
+            Operator::StartsWith => "startsWith",
+            Operator::EndsWith => "endsWith",
+            Operator::Matches => "matches",
+        }
+    }
+
+    /// The operator a token spells, or `None` if it spells none.
+    ///
+    /// Both spellings of the logical operators are accepted, as the grammar allows both. `**`
+    /// is handled by the caller, which is where the grammar's alias for `^` already lived.
+    fn from_token(token: &str) -> Option<Self> {
+        Some(match token {
+            "+" => Operator::Add,
+            "-" => Operator::Subtract,
+            "*" => Operator::Multiply,
+            "/" => Operator::Divide,
+            "%" => Operator::Modulo,
+            "^" => Operator::Pow,
+            "==" => Operator::Equal,
+            "!=" => Operator::NotEqual,
+            ">" => Operator::GreaterThan,
+            ">=" => Operator::GreaterThanOrEqual,
+            "<" => Operator::LessThan,
+            "<=" => Operator::LessThanOrEqual,
+            "&&" | "and" => Operator::And,
+            "||" | "or" => Operator::Or,
+            "in" => Operator::In,
+            "not in" => Operator::NotIn,
+            "contains" => Operator::Contains,
+            "startsWith" => Operator::StartsWith,
+            "endsWith" => Operator::EndsWith,
+            "matches" => Operator::Matches,
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for Operator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 impl From<Pair<'_, Rule>> for Operator {
@@ -58,7 +107,8 @@ impl From<Pair<'_, Rule>> for Operator {
         }
         match pair.as_str() {
             "**" => Operator::Pow,
-            op => Operator::from_str(op).unwrap_or_else(|_| unreachable!("Invalid operator {op}")),
+            op => Operator::from_token(op)
+                .unwrap_or_else(|| unreachable!("Invalid operator {op}")),
         }
     }
 }
@@ -113,7 +163,7 @@ impl Environment<'_> {
         operator: &Operator,
         left: &Node,
         right: &Node,
-        compiled_regex: Option<&regex::Regex>,
+        #[cfg(feature = "regex")] compiled_regex: Option<&regex::Regex>,
     ) -> Result<Value> {
         let left = self.eval_expr(ctx, left)?;
         match &operator {
@@ -147,14 +197,17 @@ impl Environment<'_> {
                 (Integer(left), Float(right)) => Float(left as f64 + right),
                 (Float(left), Integer(right)) => Float(left + right as f64),
                 (String(left), String(right)) => format!("{left}{right}").into(),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), Duration(right)) => {
                     DateTime(left.checked_add_signed(chrono::Duration::nanoseconds(right))
                         .ok_or_else(|| crate::Error::ExprError("date out of range".into()))?)
                 }
+                #[cfg(feature = "temporal")]
                 (Duration(left), DateTime(right)) => {
                     DateTime(right.checked_add_signed(chrono::Duration::nanoseconds(left))
                         .ok_or_else(|| crate::Error::ExprError("date out of range".into()))?)
                 }
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => Duration(left.wrapping_add(right)),
                 _ => bail!("Invalid operands for operator +"),
             },
@@ -163,15 +216,18 @@ impl Environment<'_> {
                 (Float(left), Float(right)) => Float(left - right),
                 (Integer(left), Float(right)) => Float(left as f64 - right),
                 (Float(left), Integer(right)) => Float(left - right as f64),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), DateTime(right)) => Duration(
                     (left - right)
                         .num_nanoseconds()
                         .ok_or_else(|| crate::Error::ExprError("duration out of range".into()))?,
                 ),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), Duration(right)) => {
                     DateTime(left.checked_sub_signed(chrono::Duration::nanoseconds(right))
                         .ok_or_else(|| crate::Error::ExprError("date out of range".into()))?)
                 }
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => Duration(left.wrapping_sub(right)),
                 _ => bail!("Invalid operands for operator -"),
             },
@@ -180,7 +236,9 @@ impl Environment<'_> {
                 (Float(left), Float(right)) => Float(left * right),
                 (Integer(left), Float(right)) => Float(left as f64 * right),
                 (Float(left), Integer(right)) => Float(left * right as f64),
+                #[cfg(feature = "temporal")]
                 (Duration(left), Integer(right)) => Duration(left.wrapping_mul(right)),
+                #[cfg(feature = "temporal")]
                 (Integer(left), Duration(right)) => Duration(left.wrapping_mul(right)),
                 _ => bail!("Invalid operands for operator *"),
             },
@@ -204,6 +262,7 @@ impl Environment<'_> {
                 _ => bail!("Invalid operands for operator {operator}"),
             },
             Operator::Equal => match (&left, &right) {
+                #[cfg(feature = "temporal")]
                 (Month(_) | Weekday(_), Integer(_))
                 | (Integer(_), Month(_) | Weekday(_)) => {
                     bail!("Invalid operands for operator {operator}")
@@ -214,6 +273,7 @@ impl Environment<'_> {
                 _ => Bool(values_equal(&left, &right)),
             },
             Operator::NotEqual => match (&left, &right) {
+                #[cfg(feature = "temporal")]
                 (Month(_) | Weekday(_), Integer(_))
                 | (Integer(_), Month(_) | Weekday(_)) => {
                     bail!("Invalid operands for operator {operator}")
@@ -229,7 +289,9 @@ impl Environment<'_> {
                 (Integer(left), Float(right)) => (left as f64 > right).into(),
                 (Float(left), Integer(right)) => (left > right as f64).into(),
                 (String(left), String(right)) => (left > right).into(),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), DateTime(right)) => (left > right).into(),
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => (left > right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
@@ -239,7 +301,9 @@ impl Environment<'_> {
                 (Integer(left), Float(right)) => (left as f64 >= right).into(),
                 (Float(left), Integer(right)) => (left >= right as f64).into(),
                 (String(left), String(right)) => (left >= right).into(),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), DateTime(right)) => (left >= right).into(),
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => (left >= right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
@@ -249,7 +313,9 @@ impl Environment<'_> {
                 (Integer(left), Float(right)) => ((left as f64) < right).into(),
                 (Float(left), Integer(right)) => (left < right as f64).into(),
                 (String(left), String(right)) => (left < right).into(),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), DateTime(right)) => (left < right).into(),
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => (left < right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
@@ -259,7 +325,9 @@ impl Environment<'_> {
                 (Integer(left), Float(right)) => (left as f64 <= right).into(),
                 (Float(left), Integer(right)) => (left <= right as f64).into(),
                 (String(left), String(right)) => (left <= right).into(),
+                #[cfg(feature = "temporal")]
                 (DateTime(left), DateTime(right)) => (left <= right).into(),
+                #[cfg(feature = "temporal")]
                 (Duration(left), Duration(right)) => (left <= right).into(),
                 _ => bail!("Invalid operands for operator {operator}"),
             },
@@ -302,6 +370,7 @@ impl Environment<'_> {
                 (String(left), String(right)) => Bool(left.ends_with(&right)),
                 _ => bail!("Invalid operands for operator endsWith"),
             },
+            #[cfg(feature = "regex")]
             Operator::Matches => match (left, right) {
                 (String(left), String(right)) => {
                     if let Some(regex) = compiled_regex {
@@ -312,6 +381,10 @@ impl Environment<'_> {
                 }
                 _ => bail!("Invalid operands for operator matches"),
             },
+            // Reachable only because the grammar has no features: the operator parses, and
+            // says what is missing rather than pretending the pattern did not match.
+            #[cfg(not(feature = "regex"))]
+            Operator::Matches => bail!("the `matches` operator requires the `regex` feature"),
         };
 
         Ok(result)

--- a/src/ast/postfix_operator.rs
+++ b/src/ast/postfix_operator.rs
@@ -6,7 +6,7 @@ use log::trace;
 use pest::iterators::Pair;
 use std::iter::once;
 
-#[derive(Debug, Clone, strum::Display)]
+#[derive(Debug, Clone)]
 pub enum PostfixOperator {
     Index { idx: Box<Node>, optional: bool },
     Range {
@@ -183,6 +183,14 @@ impl Environment<'_> {
                     .iter()
                     .map(|arg| self.eval_expr(ctx, arg))
                     .collect::<Result<Vec<_>>>()?;
+                // Every method the language has is a method on a temporal value, so without
+                // that feature there is no method to dispatch to.
+                #[cfg(not(feature = "temporal"))]
+                {
+                    let _ = args;
+                    bail!("unknown method {ident}: methods require the `temporal` feature")
+                }
+                #[cfg(feature = "temporal")]
                 crate::functions::temporal::eval_method(value, ident, args)?
             }
         };

--- a/src/ast/unary_operator.rs
+++ b/src/ast/unary_operator.rs
@@ -5,15 +5,11 @@ use crate::{bail, Result};
 use crate::{ContextProvider, Environment, Value};
 use log::trace;
 use pest::iterators::Pair;
-use std::str::FromStr;
 
-#[derive(Debug, Clone, strum::EnumString)]
+#[derive(Debug, Clone)]
 pub enum UnaryOperator {
-    #[strum(serialize = "!")]
     Not,
-    #[strum(serialize = "+")]
     Positive,
-    #[strum(serialize = "-")]
     Negative,
 }
 
@@ -21,9 +17,10 @@ impl From<Pair<'_, Rule>> for UnaryOperator {
     fn from(pair: Pair<Rule>) -> Self {
         trace!("[unary_operator] {pair:?}");
         match pair.as_str() {
-            "not" => UnaryOperator::Not,
-            op => UnaryOperator::from_str(op)
-                .unwrap_or_else(|_| unreachable!("Invalid operator {op}")),
+            "not" | "!" => UnaryOperator::Not,
+            "+" => UnaryOperator::Positive,
+            "-" => UnaryOperator::Negative,
+            op => unreachable!("Invalid operator {op}"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,60 @@
 use crate::Rule;
-use std::fmt::Debug;
-use thiserror::Error;
+use std::fmt::{self, Debug, Display};
+
 /// An error that can occur when parsing or evaluating an expr program
-#[derive(Error)]
+//
+// `Display`, `Error` and the two `From`s are written out rather than derived: `Debug` below
+// already is, and a `derive` was the whole reason this crate pulled thiserror into every
+// dependent's build for one 20-line enum.
 pub enum Error {
-    #[error(transparent)]
-    PestError(#[from] Box<pest::error::Error<Rule>>),
-    #[error("{0}")]
+    PestError(Box<pest::error::Error<Rule>>),
     ParseError(String),
-    #[error("{0}")]
     ExprError(String),
-    #[error(transparent)]
-    RegexError(#[from] regex::Error),
+    #[cfg(feature = "regex")]
+    RegexError(regex::Error),
     #[cfg(feature = "serde")]
-    #[error("{0}")]
     DeserializeError(String),
     #[cfg(feature = "serde")]
-    #[error("{0}")]
     SerializeError(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // Transparent, as they were: a pest error already says where it is, and prefixing
+            // it would bury that.
+            Error::PestError(e) => Display::fmt(e, f),
+            #[cfg(feature = "regex")]
+            Error::RegexError(e) => Display::fmt(e, f),
+            Error::ParseError(e) | Error::ExprError(e) => f.write_str(e),
+            #[cfg(feature = "serde")]
+            Error::DeserializeError(e) | Error::SerializeError(e) => f.write_str(e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::PestError(e) => Some(e),
+            #[cfg(feature = "regex")]
+            Error::RegexError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<Box<pest::error::Error<Rule>>> for Error {
+    fn from(err: Box<pest::error::Error<Rule>>) -> Self {
+        Error::PestError(err)
+    }
+}
+
+#[cfg(feature = "regex")]
+impl From<regex::Error> for Error {
+    fn from(err: regex::Error) -> Self {
+        Error::RegexError(err)
+    }
 }
 
 impl From<String> for Error {
@@ -32,6 +69,7 @@ impl Debug for Error {
             Error::PestError(e) => write!(f, "PestError: {}", e),
             Error::ParseError(e) => write!(f, "ParseError: {}", e),
             Error::ExprError(e) => write!(f, "ExprError: {}", e),
+            #[cfg(feature = "regex")]
             Error::RegexError(e) => write!(f, "RegexError: {}", e),
             #[cfg(feature = "serde")]
             Error::DeserializeError(e) => write!(f, "DeserializeError: {}", e),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -75,6 +75,12 @@ impl<'a> Environment<'a> {
         string::add_string_functions(&mut p);
         #[cfg(feature = "temporal")]
         crate::functions::temporal::add_temporal_functions(&mut p);
+        #[cfg(not(feature = "temporal"))]
+        crate::functions::add_disabled_functions(
+            &mut p,
+            "temporal",
+            &["now", "date", "duration", "timezone"],
+        );
         array::add_array_functions(&mut p);
         bitwise::add_bitwise_functions(&mut p);
         collection::add_collection_functions(&mut p);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2,12 +2,12 @@ use crate::ast::node::Node;
 use crate::ast::program::Program;
 use crate::context::ContextScope;
 use crate::functions::{
-    array, bitwise, collection, convert, json, misc, number, string, temporal, ExprCall, Function,
+    array, bitwise, collection, convert, json, misc, number, string, ExprCall, Function,
 };
 use crate::parser::compile;
 use crate::{bail, ContextProvider, Result, Value};
 use indexmap::IndexMap;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
@@ -73,7 +73,8 @@ impl<'a> Environment<'a> {
             functions: IndexMap::new(),
         };
         string::add_string_functions(&mut p);
-        temporal::add_temporal_functions(&mut p);
+        #[cfg(feature = "temporal")]
+        crate::functions::temporal::add_temporal_functions(&mut p);
         array::add_array_functions(&mut p);
         bitwise::add_bitwise_functions(&mut p);
         collection::add_collection_functions(&mut p);
@@ -187,12 +188,19 @@ impl<'a> Environment<'a> {
                     .collect::<Result<_>>()?;
                 self.eval_func(ctx, ident, args, predicate.as_deref())?
             }
+            #[cfg(feature = "regex")]
             Node::Operation {
                 left,
                 operator,
                 right,
                 compiled_regex,
             } => self.eval_operator(ctx, operator, left, right, compiled_regex.as_ref())?,
+            #[cfg(not(feature = "regex"))]
+            Node::Operation {
+                left,
+                operator,
+                right,
+            } => self.eval_operator(ctx, operator, left, right)?,
             Node::Unary { operator, node } => self.eval_unary_operator(ctx, operator, node)?,
             Node::Postfix { operator, node } => self.eval_postfix_operator(ctx, operator, node)?,
             Node::Array(a) => Value::Array(
@@ -220,4 +228,4 @@ impl<'a> Environment<'a> {
     }
 }
 
-pub(crate) static DEFAULT_ENVIRONMENT: Lazy<Environment> = Lazy::new(Environment::new);
+pub(crate) static DEFAULT_ENVIRONMENT: LazyLock<Environment> = LazyLock::new(Environment::new);

--- a/src/functions/convert.rs
+++ b/src/functions/convert.rs
@@ -83,10 +83,15 @@ fn expr_string(value: &Value) -> String {
             "[{}]",
             values.iter().map(u8::to_string).collect::<Vec<_>>().join(" ")
         ),
+        #[cfg(feature = "temporal")]
         Value::DateTime(value) => crate::functions::temporal::format_datetime(value),
+        #[cfg(feature = "temporal")]
         Value::Duration(value) => crate::functions::temporal::format_duration(*value),
+        #[cfg(feature = "temporal")]
         Value::Timezone(value) => value.to_string(),
+        #[cfg(feature = "temporal")]
         Value::Month(value) => crate::functions::temporal::month_name(*value).to_string(),
+        #[cfg(feature = "temporal")]
         Value::Weekday(value) => crate::functions::temporal::weekday_name(*value).to_string(),
         Value::Array(values) => format!(
             "[{}]",
@@ -131,9 +136,13 @@ fn compare_map_keys(left: &Value, right: &Value) -> std::cmp::Ordering {
             _ => left.partial_cmp(right).unwrap_or(Ordering::Equal),
         },
         (Value::String(left), Value::String(right)) => left.cmp(right),
+        #[cfg(feature = "temporal")]
         (Value::Duration(left), Value::Duration(right)) => left.cmp(right),
+        #[cfg(feature = "temporal")]
         (Value::Month(left), Value::Month(right)) | (Value::Weekday(left), Value::Weekday(right)) => left.cmp(right),
+        #[cfg(feature = "temporal")]
         (Value::DateTime(left), Value::DateTime(right)) => left.partial_cmp(right).unwrap_or(Ordering::Equal),
+        #[cfg(feature = "temporal")]
         (Value::Timezone(left), Value::Timezone(right)) => left.name().cmp(right.name()),
         _ => expr_string(left).cmp(&expr_string(right)),
     }

--- a/src/functions/json.rs
+++ b/src/functions/json.rs
@@ -1,10 +1,16 @@
+#[cfg(feature = "json")]
 use serde_json;
 
-use crate::{bail, Environment, Result, Value};
+use crate::{bail, Environment, Value};
+#[cfg(feature = "json")]
+use crate::Result;
+#[cfg(feature = "json")]
 use base64::Engine;
+#[cfg(feature = "json")]
 use base64::engine::general_purpose::STANDARD;
 
 /// Convert a serde_json::Value to an expr::Value
+#[cfg(feature = "json")]
 fn json_to_value(json: serde_json::Value) -> Value {
     match json {
         serde_json::Value::Null => Value::Nil,
@@ -29,6 +35,7 @@ fn json_to_value(json: serde_json::Value) -> Value {
 }
 
 /// Convert an expr::Value to a serde_json::Value
+#[cfg(feature = "json")]
 fn value_to_json(value: &Value) -> Result<serde_json::Value> {
     Ok(match value {
         Value::Nil => serde_json::Value::Null,
@@ -41,11 +48,15 @@ fn value_to_json(value: &Value) -> Result<serde_json::Value> {
         }
         Value::String(s) => serde_json::Value::String(s.clone()),
         Value::Bytes(bytes) => serde_json::Value::String(STANDARD.encode(bytes)),
+        #[cfg(feature = "temporal")]
         Value::DateTime(value) => serde_json::Value::String(
             crate::functions::temporal::date_to_rfc3339(value),
         ),
+        #[cfg(feature = "temporal")]
         Value::Duration(value) => serde_json::Value::Number((*value).into()),
+        #[cfg(feature = "temporal")]
         Value::Timezone(_) => serde_json::Value::Object(Default::default()),
+        #[cfg(feature = "temporal")]
         Value::Month(value) | Value::Weekday(value) => {
             serde_json::Value::Number((*value).into())
         }
@@ -66,6 +77,7 @@ fn value_to_json(value: &Value) -> Result<serde_json::Value> {
 pub fn add_json_functions(env: &mut Environment) {
     // fromJSON(string) -> Value
     // Parses a JSON string and returns the corresponding Value
+    #[cfg(feature = "json")]
     env.add_function("fromJSON", |c| {
         if c.args.len() != 1 {
             bail!("fromJSON() takes exactly one argument");
@@ -82,6 +94,7 @@ pub fn add_json_functions(env: &mut Environment) {
 
     // toJSON(value) -> String
     // Serializes a value to a JSON string
+    #[cfg(feature = "json")]
     env.add_function("toJSON", |c| {
         if c.args.len() != 1 {
             bail!("toJSON() takes exactly one argument");

--- a/src/functions/json.rs
+++ b/src/functions/json.rs
@@ -75,6 +75,11 @@ fn value_to_json(value: &Value) -> Result<serde_json::Value> {
 }
 
 pub fn add_json_functions(env: &mut Environment) {
+    // `keys`, `values` and `len` are in this module too and are not JSON: they read a map or
+    // an array and need no crate to do it, so only the codec follows the feature.
+    #[cfg(not(feature = "json"))]
+    super::add_disabled_functions(env, "json", &["fromJSON", "toJSON"]);
+
     // fromJSON(string) -> Value
     // Parses a JSON string and returns the corresponding Value
     #[cfg(feature = "json")]

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -83,6 +83,8 @@ pub fn add_misc_functions(env: &mut Environment) {
         }
     });
 
+    #[cfg(not(feature = "base64"))]
+    super::add_disabled_functions(env, "base64", &["toBase64", "fromBase64"]);
     #[cfg(feature = "base64")]
     env.add_function("toBase64", |call| match one_argument("toBase64", call.args)? {
         Value::String(value) => Ok(Value::from(STANDARD.encode(value))),

--- a/src/functions/misc.rs
+++ b/src/functions/misc.rs
@@ -1,5 +1,9 @@
-use crate::{Environment, Error, Value, bail};
+use crate::{Environment, Value, bail};
+#[cfg(feature = "base64")]
+use crate::Error;
+#[cfg(feature = "base64")]
 use base64::Engine;
+#[cfg(feature = "base64")]
 use base64::engine::general_purpose::STANDARD;
 
 fn one_argument(name: &str, mut args: Vec<Value>) -> crate::Result<Value> {
@@ -19,10 +23,15 @@ pub fn add_misc_functions(env: &mut Environment) {
             Value::Float(_) => "float",
             Value::String(_) => "string",
             Value::Bytes(_) => "array",
+            #[cfg(feature = "temporal")]
             Value::DateTime(_) => "time.Time",
+            #[cfg(feature = "temporal")]
             Value::Duration(_) => "time.Duration",
+            #[cfg(feature = "temporal")]
             Value::Timezone(_) => "time.Location",
+            #[cfg(feature = "temporal")]
             Value::Month(_) => "time.Month",
+            #[cfg(feature = "temporal")]
             Value::Weekday(_) => "time.Weekday",
             Value::Array(_) => "array",
             Value::Map(_) => "map",
@@ -74,10 +83,12 @@ pub fn add_misc_functions(env: &mut Environment) {
         }
     });
 
+    #[cfg(feature = "base64")]
     env.add_function("toBase64", |call| match one_argument("toBase64", call.args)? {
         Value::String(value) => Ok(Value::from(STANDARD.encode(value))),
         _ => bail!("toBase64() takes a string as the argument"),
     });
+    #[cfg(feature = "base64")]
     env.add_function("fromBase64", |call| match one_argument("fromBase64", call.args)? {
         Value::String(value) => {
             let decoded = STANDARD

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -6,6 +6,7 @@ pub mod json;
 pub mod misc;
 pub mod number;
 pub mod string;
+#[cfg(feature = "temporal")]
 pub mod temporal;
 
 use crate::Result;

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -14,6 +14,28 @@ use crate::Result;
 use crate::ast::program::Program;
 use crate::{bail, ContextProvider, Environment, Value};
 
+/// Register builtins that report the feature they need instead of not existing.
+///
+/// A builtin whose feature is off is still a builtin the language has: `Unknown function:
+/// fromJSON` sends an author hunting for a typo, when what is missing is a Cargo feature and
+/// only the person who chose the features can fix it. Same contract as the `matches` operator
+/// and method dispatch, which report their own features.
+#[cfg(not(all(feature = "base64", feature = "json", feature = "temporal")))]
+pub(crate) fn add_disabled_functions(
+    env: &mut Environment,
+    feature: &'static str,
+    names: &[&'static str],
+) {
+    for name in names {
+        env.add_function(name, move |call| {
+            bail!(
+                "{}() requires expr-lang's `{feature}` feature",
+                call.ident
+            )
+        });
+    }
+}
+
 pub type Function<'a> = Box<dyn Fn(ExprCall) -> Result<Value> + 'a + Sync + Send>;
 
 pub struct ExprCall<'a, 'b> {

--- a/src/functions/temporal.rs
+++ b/src/functions/temporal.rs
@@ -1,7 +1,7 @@
 use crate::{bail, value::{DateTimeValue, TimezoneValue}, Environment, Error, Value};
 use chrono::{DateTime, Datelike, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc};
 use chrono_tz::{OffsetComponents, Tz};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 
 const NANOS_PER_MICRO: i64 = 1_000;
@@ -10,12 +10,12 @@ const NANOS_PER_SECOND: i64 = 1_000_000_000;
 const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
 const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
 
-static COMPACT_OFFSET: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"([+-])(\d{2})(\d{2})(\d{2})").expect("valid offset regex"));
-static SECONDS_OFFSET: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"([+-])(\d{2}):(\d{2}):(\d{2})").expect("valid offset regex"));
-static TRAILING_ZONE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"([A-Za-z]{3,5})\s*$").expect("valid zone-name regex"));
+static COMPACT_OFFSET: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([+-])(\d{2})(\d{2})(\d{2})").expect("valid offset regex"));
+static SECONDS_OFFSET: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([+-])(\d{2}):(\d{2}):(\d{2})").expect("valid offset regex"));
+static TRAILING_ZONE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([A-Za-z]{3,5})\s*$").expect("valid zone-name regex"));
 
 pub fn add_temporal_functions(env: &mut Environment) {
     env.add_function("now", |call| {
@@ -676,6 +676,8 @@ fn round_datetime(value: DateTimeValue, unit: i64, round: bool) -> crate::Result
         .ok_or_else(|| Error::ExprError("date out of range".to_string()))
 }
 
+// Read by `toJSON`, which is the only caller outside this module.
+#[cfg(feature = "json")]
 pub(crate) fn date_to_rfc3339(value: &DateTimeValue) -> String {
     format_go_layout(value, "2006-01-02T15:04:05.999999999Z07:00")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@ pub use crate::parser::compile;
 #[allow(deprecated)]
 pub use crate::parser::Parser;
 pub use crate::ast::program::Program;
-pub use crate::value::{DateTimeValue, TimezoneValue, Value};
+#[cfg(feature = "temporal")]
+pub use crate::value::{DateTimeValue, TimezoneValue};
+pub use crate::value::Value;
 #[cfg(feature = "serde")]
 pub use crate::serde::{from_value, to_value};
 

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -1,8 +1,8 @@
 use crate::Rule;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use pest::pratt_parser::PrattParser;
 
-pub(crate) static PRATT_PARSER: Lazy<PrattParser<Rule>> = Lazy::new(|| {
+pub(crate) static PRATT_PARSER: LazyLock<PrattParser<Rule>> = LazyLock::new(|| {
     use pest::pratt_parser::{Assoc::*, Op};
     use Rule::*;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -41,9 +41,13 @@ impl<'de> Deserializer<'de> for ValueDeserializer {
             Value::Bool(b) => visitor.visit_bool(b),
             Value::String(s) => visitor.visit_string(s),
             Value::Bytes(bytes) => visitor.visit_byte_buf(bytes),
+            #[cfg(feature = "temporal")]
             Value::DateTime(value) => visitor.visit_string(value.to_rfc3339()),
+            #[cfg(feature = "temporal")]
             Value::Duration(value) => visitor.visit_i64(value),
+            #[cfg(feature = "temporal")]
             Value::Timezone(value) => visitor.visit_string(value.to_string()),
+            #[cfg(feature = "temporal")]
             Value::Month(value) | Value::Weekday(value) => visitor.visit_u32(value),
             Value::Array(a) => visitor.visit_seq(SeqDeserializer::new(a.into_iter())),
             Value::Map(m) => visitor.visit_map(MapDeserializer::new(m.into_iter())),

--- a/src/test.rs
+++ b/src/test.rs
@@ -183,8 +183,11 @@ fn string() -> Result<()> {
     test_old!(r#""foo" <= "foo""#, "true");
     test_old!(r#""bar" >= "foo""#, "false");
     test_old!(r#""foo" >= "foo""#, "true");
-    test_old!(r#""foo" matches "^f""#, "true");
-    test_old!(r#""foo" matches "^x""#, "false");
+    #[cfg(feature = "regex")]
+    {
+        test_old!(r#""foo" matches "^f""#, "true");
+        test_old!(r#""foo" matches "^x""#, "false");
+    }
     test_old!(
         r#"`foo
 bar`"#,
@@ -193,6 +196,7 @@ bar`"#,
     Ok(())
 }
 
+#[cfg(feature = "regex")]
 #[test]
 fn dynamic_matches() -> Result<()> {
     let ctx = Context::from_iter([("pattern", "^f")]);
@@ -256,6 +260,7 @@ fn map() -> Result<()> {
 #[test]
 fn context() -> Result<()> {
     let ctx = Context::from_iter([("Version".to_string(), "v1.0.0".to_string())]);
+    #[cfg(feature = "regex")]
     assert_eq!(
         eval(r#"Version matches "^v\\d+\\.\\d+\\.\\d+""#, &ctx)?
             .to_string(),
@@ -541,6 +546,7 @@ test!(
     "true"
 );
 
+#[cfg(feature = "regex")]
 test!(
     precedence_matches_vs_and,
     r#""foo123" matches "^1" and "123foo" matches "^1""#,
@@ -560,24 +566,41 @@ test!(
 );
 
 // fromJSON tests
+#[cfg(feature = "json")]
 test!(from_json_object, r#"fromJSON("{\"foo\": \"bar\"}")"#, "{{foo: \"bar\"}}");
+#[cfg(feature = "json")]
 test!(from_json_object_access, r#"fromJSON("{\"foo\": \"bar\"}").foo"#, r#""bar""#);
+#[cfg(feature = "json")]
 test!(from_json_array, r#"fromJSON("[1, 2, 3]")"#, "[1, 2, 3]");
+#[cfg(feature = "json")]
 test!(from_json_number, r#"fromJSON("123")"#, "123");
+#[cfg(feature = "json")]
 test!(from_json_float, r#"fromJSON("1.5")"#, "1.5");
+#[cfg(feature = "json")]
 test!(from_json_true, r#"fromJSON("true")"#, "true");
+#[cfg(feature = "json")]
 test!(from_json_false, r#"fromJSON("false")"#, "false");
+#[cfg(feature = "json")]
 test!(from_json_null, r#"fromJSON("null")"#, "nil");
+#[cfg(feature = "json")]
 test!(from_json_string, r#"fromJSON("\"hello\"")"#, r#""hello""#);
+#[cfg(feature = "json")]
 test!(from_json_nested, r#"fromJSON("{\"a\": {\"b\": 1}}").a.b"#, "1");
+#[cfg(feature = "json")]
 test!(from_json_array_access, r#"fromJSON("[1, 2, 3]")[1]"#, "2");
 
 // toJSON tests
+#[cfg(feature = "json")]
 test!(to_json_array, r#"toJSON([1, 2, 3])"#, r#""[1,2,3]""#);
+#[cfg(feature = "json")]
 test!(to_json_number, r#"toJSON(123)"#, r#""123""#);
+#[cfg(feature = "json")]
 test!(to_json_float, r#"toJSON(1.5)"#, r#""1.5""#);
+#[cfg(feature = "json")]
 test!(to_json_true, r#"toJSON(true)"#, r#""true""#);
+#[cfg(feature = "json")]
 test!(to_json_false, r#"toJSON(false)"#, r#""false""#);
+#[cfg(feature = "json")]
 test!(to_json_nil, r#"toJSON(nil)"#, r#""null""#);
 
 // keys tests
@@ -587,6 +610,7 @@ test!(keys_single, r#"keys({a: 1})"#, r#"["a"]"#);
 
 // Test that JSON keys preserve insertion order (not alphabetical)
 // This is critical for version lists where "0.40.0" should come after "0.39.0", not before "0.5.0"
+#[cfg(feature = "json")]
 test!(
     keys_preserve_insertion_order,
     r#"keys(fromJSON("{\"z\": 1, \"a\": 2, \"m\": 3}"))"#,
@@ -627,3 +651,45 @@ proptest! {
 
 // pipe tests
 test!(pipe_sort, r#"[3, 1, 2] | sort()"#, "[1, 2, 3]");
+
+// What a disabled feature says. These compile only when the feature is off, which
+// `mise run lint:features` is what exercises — `cargo test --all-features` cannot reach them.
+#[cfg(not(feature = "json"))]
+#[test]
+fn a_disabled_json_builtin_names_its_feature() {
+    let err = eval("fromJSON('{}')", &Context::default()).expect_err("json is off");
+    assert!(
+        err.to_string().contains("requires expr-lang's `json` feature"),
+        "{err}"
+    );
+}
+
+#[cfg(not(feature = "base64"))]
+#[test]
+fn a_disabled_base64_builtin_names_its_feature() {
+    let err = eval("toBase64('hi')", &Context::default()).expect_err("base64 is off");
+    assert!(
+        err.to_string().contains("requires expr-lang's `base64` feature"),
+        "{err}"
+    );
+}
+
+#[cfg(not(feature = "temporal"))]
+#[test]
+fn disabled_temporal_names_its_feature_for_builtins_and_methods() {
+    let err = eval("now()", &Context::default()).expect_err("temporal is off");
+    assert!(
+        err.to_string().contains("requires expr-lang's `temporal` feature"),
+        "{err}"
+    );
+    // Methods are the other half: the grammar still parses `.Year()`.
+    let err = eval("'x'.Year()", &Context::default()).expect_err("temporal is off");
+    assert!(err.to_string().contains("`temporal` feature"), "{err}");
+}
+
+#[cfg(not(feature = "regex"))]
+#[test]
+fn a_disabled_matches_operator_names_its_feature() {
+    let err = eval("'a' matches 'a'", &Context::default()).expect_err("regex is off");
+    assert!(err.to_string().contains("`regex` feature"), "{err}");
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,9 +6,11 @@ use pest::iterators::{Pair, Pairs};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
+#[cfg(feature = "temporal")]
 use std::ops::{Add, Deref, Sub};
 
 /// A time value together with the named timezone, when one is known.
+#[cfg(feature = "temporal")]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
@@ -20,6 +22,7 @@ pub struct DateTimeValue {
     zone_name: Option<String>,
 }
 
+#[cfg(feature = "temporal")]
 impl DateTimeValue {
     pub fn fixed(value: chrono::DateTime<chrono::FixedOffset>) -> Self {
         Self { value, timezone: None, zone_name: None }
@@ -84,12 +87,14 @@ impl DateTimeValue {
     }
 }
 
+#[cfg(feature = "temporal")]
 impl From<chrono::DateTime<chrono::FixedOffset>> for DateTimeValue {
     fn from(value: chrono::DateTime<chrono::FixedOffset>) -> Self {
         Self::fixed(value)
     }
 }
 
+#[cfg(feature = "temporal")]
 impl Deref for DateTimeValue {
     type Target = chrono::DateTime<chrono::FixedOffset>;
 
@@ -98,18 +103,21 @@ impl Deref for DateTimeValue {
     }
 }
 
+#[cfg(feature = "temporal")]
 impl PartialEq for DateTimeValue {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
     }
 }
 
+#[cfg(feature = "temporal")]
 impl PartialOrd for DateTimeValue {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.value.partial_cmp(&other.value)
     }
 }
 
+#[cfg(feature = "temporal")]
 impl Add<chrono::Duration> for DateTimeValue {
     type Output = Self;
 
@@ -120,6 +128,7 @@ impl Add<chrono::Duration> for DateTimeValue {
     }
 }
 
+#[cfg(feature = "temporal")]
 impl Sub<chrono::Duration> for DateTimeValue {
     type Output = Self;
 
@@ -133,6 +142,7 @@ impl Sub<chrono::Duration> for DateTimeValue {
 /// A timezone used by expr time values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg(feature = "temporal")]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct TimezoneValue {
     timezone: chrono_tz::Tz,
@@ -140,6 +150,7 @@ pub struct TimezoneValue {
     local: bool,
 }
 
+#[cfg(feature = "temporal")]
 impl TimezoneValue {
     /// Creates a named IANA timezone.
     pub fn named(timezone: chrono_tz::Tz) -> Self {
@@ -185,6 +196,7 @@ impl TimezoneValue {
     }
 }
 
+#[cfg(feature = "temporal")]
 fn timezone_from_env(value: &std::ffi::OsStr) -> chrono_tz::Tz {
     value
         .to_str()
@@ -198,12 +210,14 @@ fn timezone_from_env(value: &std::ffi::OsStr) -> chrono_tz::Tz {
         .unwrap_or(chrono_tz::UTC)
 }
 
+#[cfg(feature = "temporal")]
 impl From<chrono_tz::Tz> for TimezoneValue {
     fn from(timezone: chrono_tz::Tz) -> Self {
         Self::named(timezone)
     }
 }
 
+#[cfg(feature = "temporal")]
 impl Display for TimezoneValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.name())
@@ -232,6 +246,7 @@ mod timezone_tests {
     }
 }
 
+#[cfg(feature = "temporal")]
 impl Sub for DateTimeValue {
     type Output = chrono::Duration;
 
@@ -251,10 +266,15 @@ pub enum Value {
     #[default]
     Nil,
     String(String),
+    #[cfg(feature = "temporal")]
     DateTime(DateTimeValue),
+    #[cfg(feature = "temporal")]
     Duration(i64),
+    #[cfg(feature = "temporal")]
     Timezone(TimezoneValue),
+    #[cfg(feature = "temporal")]
     Month(u32),
+    #[cfg(feature = "temporal")]
     Weekday(u32),
     Array(Vec<Value>),
     // Keep Bytes after Array so untagged serde treats JSON integer arrays as arrays.
@@ -315,6 +335,7 @@ impl Value {
         }
     }
 
+    #[cfg(feature = "temporal")]
     pub fn as_datetime(&self) -> Option<&chrono::DateTime<chrono::FixedOffset>> {
         match self {
             Value::DateTime(value) => Some(&value.value),
@@ -322,6 +343,7 @@ impl Value {
         }
     }
 
+    #[cfg(feature = "temporal")]
     pub fn as_duration(&self) -> Option<i64> {
         match self {
             Value::Duration(value) => Some(*value),
@@ -457,9 +479,13 @@ impl Display for Value {
                     .collect::<Vec<String>>()
                     .join(" ")
             ),
+            #[cfg(feature = "temporal")]
             Value::DateTime(value) => write!(f, "{}", value.to_rfc3339()),
+            #[cfg(feature = "temporal")]
             Value::Duration(value) => write!(f, "{value}ns"),
+            #[cfg(feature = "temporal")]
             Value::Timezone(value) => write!(f, "{value}"),
+            #[cfg(feature = "temporal")]
             Value::Month(value) | Value::Weekday(value) => write!(f, "{value}"),
             Value::Array(a) => write!(
                 f,

--- a/src/value.rs
+++ b/src/value.rs
@@ -224,7 +224,7 @@ impl Display for TimezoneValue {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "temporal"))]
 mod timezone_tests {
     use super::*;
 

--- a/tests/go_compat.rs
+++ b/tests/go_compat.rs
@@ -1,3 +1,13 @@
+//! Parity with the Go implementation, over the whole language — so it needs the whole
+//! language. With a builtin's feature off there is nothing here to compare against; the lean
+//! build's own contract is tested in `src/test.rs`.
+#![cfg(all(
+    feature = "base64",
+    feature = "json",
+    feature = "regex",
+    feature = "temporal"
+))]
+
 use expr::{eval, Context, Value as ExprValue};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;


### PR DESCRIPTION
Every dependent compiles 33 crates for the evaluator regardless of what its expressions use. A CLI validating a flag with `int(value) > 0` compiles a timezone database, a JSON codec, a regex engine and base64. (That is how I got here: it is the entire cost of [usage](https://github.com/jdx/usage)'s `validation` feature.)

## Six crates go away for everyone — no feature, no API change

| Crate | Replaced by |
| --- | --- |
| `strum` + `strum_macros` (+ a second `syn` build) | hand-written tables on `Operator` / `UnaryOperator` / `PostfixOperator` |
| `once_cell` | `std::sync::LazyLock` — stable since 1.80, MSRV here is 1.85 |
| `thiserror` + `thiserror-impl` | `Display` and `Error` written beside the `Debug` this enum already hand-wrote |
| `serde` | it was arriving unconditionally; see below |

The strum removal is safe because the strings were already listed one per variant in the attributes and the grammar constrains the input set — `**` was hand-written next to them already. `Display` keeps exactly what strum produced, `and`/`or` included rather than `&&`/`||`: those reach users through `"Invalid operands for operator {operator}"`, so I checked what strum actually emitted before writing the table rather than assuming.

`serde` was pulled in by `chrono = { features = ["serde"] }` and `chrono-tz = { features = ["serde"] }` on the dependency lines — unconditionally, whether or not this crate's own `serde` feature was on. Moved under it.

The hand-written `Error` impl also implements `source()` for the two variants that wrap an error, which the derive was not doing.

## And the rest becomes optional

All on by default, so a dependent that says nothing sees no change:

| Feature | Default | Enables | Crates |
| --- | :---: | --- | ---: |
| `temporal` | yes | `now`, `date`, `duration`, `timezone`, every `.Year()`-style method, and the datetime/duration/timezone/month/weekday values | 7 |
| `json` | yes | `fromJSON`, `toJSON` (implies `base64`) | 4 |
| `regex` | yes | the `matches` operator | 4 |
| `base64` | yes | `toBase64`, `fromBase64` | 1 |

```
default features:      30 crates
no-default-features:   14 crates
```

`keys`, `values`, `len`, the string and array builtins, arithmetic, comparison, `?:`, `??` and pipes are all in the base — they need nothing but the parser. `pest` and `indexmap` stay: the grammar *is* the crate, and map iteration order is observable through `keys` / `toPairs` and deliberately matches `serde_json`'s `preserve_order`.

The grammar has no features, so `matches` and `.Year()` still parse with their feature off — they report which feature is missing rather than returning a wrong answer.

## Coverage

`mise lint` gained a `lint:features` task that clippies each feature on its own, plus the empty set. `--all-features` is the one combination that proves nothing about the features — it is the crate exactly as it was before they existed — and the empty set is the one most likely to rot silently. All eight combinations are clean at `-D warnings`; `cargo test --all-features` is 142 tests green; `cargo package` is clean.

`cargo-semver-checks` runs on `all-features` here, where the public surface is unchanged.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `Value`/`Error` variants and datetime types are now feature-gated, so lean builds change the type surface even though defaults preserve the full language. Feature-matrix coverage reduces the chance of a broken combination.
> 
> **Overview**
> Dependents can now drop unused language surface: `temporal`, `json`, `regex`, and `base64` are default-on Cargo features, so existing users see no change, while `default-features = false` cuts the tree from ~30 crates to ~14.
> 
> Disabled builtins still parse and name the missing feature (`fromJSON() requires … json`, `matches` needs `regex`, methods need `temporal`) instead of looking like typos. `Value` datetime variants, `DateTimeValue`/`TimezoneValue` re-exports, and `Error::RegexError` follow those features.
> 
> Unconditionally dropped `strum`, `once_cell`, and `thiserror` (hand-written operator tables, `LazyLock`, and `Error` impls). Chrono serde is gated on this crate’s `serde` feature so serde is no longer pulled in by accident. Lint/test now covers the empty set and each feature in isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8010aad437f1c571660a7f208e6ca19e649e70d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable features for Base64, JSON, regular expressions, temporal values, and Serde support.
  * Features are enabled by default but can be selectively disabled to reduce dependency footprint.
  * Added clear errors when using functionality unavailable in the selected configuration.

* **Documentation**
  * Documented feature options, defaults, dependency costs, minimal configurations, and feature-related errors.

* **Bug Fixes**
  * Improved compatibility for builds with individual features disabled.
  * Added feature-matrix lint coverage to validate supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->